### PR TITLE
feat(engine): move opened-files block to ephemeral user message

### DIFF
--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -53,7 +53,7 @@ import {
   pruneHistory,
   squashMessages,
 } from "./prune.js";
-import { buildSystemPrompt } from "./system-prompt.js";
+import { buildOpenedFilesBlock, buildSystemPrompt } from "./system-prompt.js";
 import { buildTools } from "./tools.js";
 
 const NO_CAPABILITIES: ChannelCapabilities = {
@@ -289,7 +289,12 @@ export async function runTurn(
       modelCfg.supportsVideo,
     );
 
-    const systemTokens = estimateSystemPrompt(prompt);
+    const openedFilesBlock = await buildOpenedFilesBlock(agentSlug, session);
+    const openedFilesTokens =
+      openedFilesBlock.length > 0 ? estimateSystemPrompt(openedFilesBlock) : 0;
+
+    // Reserve tokens for both stable system prompt and ephemeral opened files.
+    const systemTokens = estimateSystemPrompt(prompt) + openedFilesTokens;
     const { modifiedHistory, newCursor } = pruneHistory(
       session.history,
       session.historyCursor,
@@ -321,12 +326,15 @@ export async function runTurn(
       modelCfg.supportsVideo,
     );
 
+    // Opened files are now in `filteredMessages`, so only pass the stable
+    // system prompt tokens to avoid double-counting.
+    const stableSystemTokens = estimateSystemPrompt(prompt);
     const usageSnapshot = computeContextUsageSnapshot({
       contextBudget,
       contextHardBudget,
       contextWindow: effectiveContextWindow,
       messages: filteredMessages,
-      systemTokens,
+      systemTokens: stableSystemTokens,
     });
     const shouldWarnBeforePrune =
       usageSnapshot.shouldWarnBeforePrune &&
@@ -336,6 +344,14 @@ export async function runTurn(
     if (shouldWarnBeforePrune) {
       promptMetadata = `${promptMetadata}\n${formatContextPruneWarning(usageSnapshot)}`;
       session.lastContextWarningCursor = session.historyCursor;
+    }
+
+    // Inject opened files as ephemeral user message before metadata.
+    if (openedFilesBlock.length > 0) {
+      filteredMessages.push({
+        content: { content: openedFilesBlock, type: "text" },
+        role: "user",
+      });
     }
 
     // Append ephemeral prompt metadata so the LLM always sees current context

--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -53,7 +53,7 @@ import {
   pruneHistory,
   squashMessages,
 } from "./prune.js";
-import { buildOpenedFilesBlock, buildSystemPrompt } from "./system-prompt.js";
+import { buildOpenedFilesBlock, buildSystemPrompt } from "#engine/system-prompt.js";
 import { buildTools } from "./tools.js";
 
 const NO_CAPABILITIES: ChannelCapabilities = {
@@ -326,8 +326,17 @@ export async function runTurn(
       modelCfg.supportsVideo,
     );
 
-    // Opened files are now in `filteredMessages`, so only pass the stable
-    // system prompt tokens to avoid double-counting.
+    // Inject opened files before the context usage snapshot so token
+    // estimates and pruning warnings account for opened-file content.
+    if (openedFilesBlock.length > 0) {
+      filteredMessages.push({
+        content: { content: openedFilesBlock, type: "text" },
+        role: "user",
+      });
+    }
+
+    // Only pass the stable system prompt tokens to avoid double-counting
+    // now that opened files are in filteredMessages.
     const stableSystemTokens = estimateSystemPrompt(prompt);
     const usageSnapshot = computeContextUsageSnapshot({
       contextBudget,
@@ -344,14 +353,6 @@ export async function runTurn(
     if (shouldWarnBeforePrune) {
       promptMetadata = `${promptMetadata}\n${formatContextPruneWarning(usageSnapshot)}`;
       session.lastContextWarningCursor = session.historyCursor;
-    }
-
-    // Inject opened files as ephemeral user message before metadata.
-    if (openedFilesBlock.length > 0) {
-      filteredMessages.push({
-        content: { content: openedFilesBlock, type: "text" },
-        role: "user",
-      });
     }
 
     // Append ephemeral prompt metadata so the LLM always sees current context

--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -24,6 +24,7 @@ import { generate as generateAnthropic } from "#engine/provider/anthropic.js";
 import { resolveModelContextWindow } from "#engine/provider/model-metadata.js";
 import { generate as generateOai } from "#engine/provider/oai.js";
 import { generate as generateOpenAiCodex } from "#engine/provider/openai-codex.js";
+import { buildOpenedFilesBlock, buildSystemPrompt } from "#engine/system-prompt.js";
 import { getToolRegistry } from "#engine/tools/index.js";
 import type { ToolContext } from "#engine/tools/tool-def.js";
 import type {
@@ -53,7 +54,6 @@ import {
   pruneHistory,
   squashMessages,
 } from "./prune.js";
-import { buildOpenedFilesBlock, buildSystemPrompt } from "#engine/system-prompt.js";
 import { buildTools } from "./tools.js";
 
 const NO_CAPABILITIES: ChannelCapabilities = {

--- a/packages/runtime/src/engine/system-prompt.ts
+++ b/packages/runtime/src/engine/system-prompt.ts
@@ -138,6 +138,8 @@ async function buildOpenedFilesBlock(agentSlug: string, session: Session): Promi
           const sectionContent = extractSectionContent(content, sectionId);
           lines.push(`<section id="${sectionId}">`, sectionContent, "</section>", "");
         }
+
+        lines.push("</file>", "");
       } else {
         // No active section filter — the whole file is relevant, so render
         // it in full. Larger files will be caught by context pruning.

--- a/packages/runtime/src/engine/system-prompt.ts
+++ b/packages/runtime/src/engine/system-prompt.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 
 import type { ConditionsConfig } from "#config/schemas/conditions.js";
@@ -76,6 +77,73 @@ function extractSectionContent(content: string, sectionId: string): string {
 
   // If no section found, return a placeholder so the agent knows something is wrong
   return `[Section "${sectionId}" not found in file content — outline may be stale. Re-read the file to refresh.]`;
+}
+
+async function buildOpenedFilesBlock(agentSlug: string, session: Session): Promise<string> {
+  const missingFiles: string[] = [];
+  const lines: string[] = [];
+
+  if (session.openedFiles.size > 0) {
+    lines.push("<opened_files>", "These are your currently open files:", "");
+
+    for (const file of session.openedFiles) {
+      const realPath = sandboxToReal(file, agentSlug);
+
+      let stats: Stats | undefined = undefined;
+      try {
+        stats = await stat(realPath);
+      } catch {
+        missingFiles.push(file);
+        session.openedFiles.delete(file);
+        session.activeFileSections.delete(file);
+        continue;
+      }
+
+      if (!stats.isFile()) {
+        missingFiles.push(file);
+        session.openedFiles.delete(file);
+        session.activeFileSections.delete(file);
+        continue;
+      }
+
+      const content = await readFile(realPath, "utf8");
+
+      const activeSections = session.activeFileSections.get(file);
+      if (activeSections !== undefined && activeSections.size > 0) {
+        // Render only the open sections with their IDs as labels
+        lines.push(
+          `<file path="${file}" size="${stats.size}" sections="${[...activeSections].join(", ")}">`,
+        );
+
+        for (const sectionId of activeSections) {
+          // Extract just the lines for this section by finding the heading/XML element
+          const sectionContent = extractSectionContent(content, sectionId);
+          lines.push(`<section id="${sectionId}">`, sectionContent, "</section>", "");
+        }
+      } else {
+        // No section filter — render the entire file
+        lines.push(`<file path="${file}" size="${stats.size}">`, content, "</file>", "");
+      }
+    }
+
+    lines.push("</opened_files>");
+  }
+
+  if (missingFiles.length > 0) {
+    session.pendingToolMessages.push({
+      content: {
+        content: missingFiles
+          .map(
+            (filePath) => `File ${filePath} moved/deleted while still open. Automatically closed.`,
+          )
+          .join("\n"),
+        type: "text",
+      },
+      role: "user",
+    });
+  }
+
+  return lines.join("\n");
 }
 
 async function buildSystemPrompt(
@@ -157,68 +225,6 @@ async function buildSystemPrompt(
     lines.push("</skills>");
   }
 
-  const missingFiles: string[] = [];
-
-  if (session.openedFiles.size > 0) {
-    lines.push("<opened_files>", "These are your currently open files:", "");
-
-    for (const file of session.openedFiles) {
-      const realPath = sandboxToReal(file, agentSlug);
-
-      let stats: Awaited<ReturnType<typeof stat>> | undefined = undefined;
-      try {
-        stats = await stat(realPath);
-      } catch {
-        missingFiles.push(file);
-        session.openedFiles.delete(file);
-        session.activeFileSections.delete(file);
-        continue;
-      }
-
-      if (!stats.isFile()) {
-        missingFiles.push(file);
-        session.openedFiles.delete(file);
-        session.activeFileSections.delete(file);
-        continue;
-      }
-
-      const content = await readFile(realPath, "utf8");
-
-      const activeSections = session.activeFileSections.get(file);
-      if (activeSections !== undefined && activeSections.size > 0) {
-        // Render only the open sections with their IDs as labels
-        lines.push(
-          `<file path="${file}" size="${stats.size}" sections="${[...activeSections].join(", ")}">`,
-        );
-
-        for (const sectionId of activeSections) {
-          // Extract just the lines for this section by finding the heading/XML element
-          const sectionContent = extractSectionContent(content, sectionId);
-          lines.push(`<section id="${sectionId}">`, sectionContent, "</section>", "");
-        }
-      } else {
-        // No section filter — render the entire file
-        lines.push(`<file path="${file}" size="${stats.size}">`, content, "</file>", "");
-      }
-    }
-
-    lines.push("</opened_files>");
-  }
-
-  if (missingFiles.length > 0) {
-    session.pendingToolMessages.push({
-      content: {
-        content: missingFiles
-          .map(
-            (filePath) => `File ${filePath} moved/deleted while still open. Automatically closed.`,
-          )
-          .join("\n"),
-        type: "text",
-      },
-      role: "user",
-    });
-  }
-
   lines.push("<metadata>", `The current session is on the platform: ${session.channel}`);
 
   if (session.channel === "discord") {
@@ -257,4 +263,4 @@ async function buildSystemPrompt(
   return lines.join("\n");
 }
 
-export { NO_CAPABILITIES, buildSystemPrompt };
+export { NO_CAPABILITIES, buildOpenedFilesBlock, buildSystemPrompt };

--- a/packages/runtime/src/engine/system-prompt.ts
+++ b/packages/runtime/src/engine/system-prompt.ts
@@ -106,22 +106,41 @@ async function buildOpenedFilesBlock(agentSlug: string, session: Session): Promi
         continue;
       }
 
-      const content = await readFile(realPath, "utf8");
+      // oxlint-disable-next-line init-declarations
+      let content: string;
+      try {
+        content = await readFile(realPath, "utf8");
+      } catch (error) {
+        // stat() succeeded but the file was removed before readFile —
+        // clean up the stale handle and skip without crashing the turn.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          missingFiles.push(file);
+          session.openedFiles.delete(file);
+          session.activeFileSections.delete(file);
+          continue;
+        }
+        throw error;
+      }
 
       const activeSections = session.activeFileSections.get(file);
       if (activeSections !== undefined && activeSections.size > 0) {
-        // Render only the open sections with their IDs as labels
+        // Render only the actively-viewed sections to limit token budget
+        // and keep the engine focused on the relevant context.
         lines.push(
           `<file path="${file}" size="${stats.size}" sections="${[...activeSections].join(", ")}">`,
         );
 
         for (const sectionId of activeSections) {
-          // Extract just the lines for this section by finding the heading/XML element
+          // extractSectionContent reduces prompt noise by returning only
+          // the matching heading/XML element and its body, omitting the
+          // rest of the file.
           const sectionContent = extractSectionContent(content, sectionId);
           lines.push(`<section id="${sectionId}">`, sectionContent, "</section>", "");
         }
       } else {
-        // No section filter — render the entire file
+        // No active section filter — the whole file is relevant, so render
+        // it in full. Larger files will be caught by context pruning.
         lines.push(`<file path="${file}" size="${stats.size}">`, content, "</file>", "");
       }
     }


### PR DESCRIPTION
Extract `<copened_files>` from `buildSystemPrompt()` into a new `buildOpenedFilesBlock()` function. The opened files are now injected as an ephemeral user-role message at message-assembly time, positioned just before `promptMetadata`.

This makes the system prompt session-stable, unlocking prefix-based LLM caching (OpenAI/OpenRouter implicit caching, Anthropic `cache_control`) for the system prompt + all persisted history.

Token budget correctness is preserved:
- `pruneHistory()` receives `systemTokens` = `prompt` + `openedFiles`
- `computeContextUsageSnapshot()` receives only `stableSystemTokens` to avoid double-counting opened files (now in `messages[]`).