### PR TITLE
fix(engine): auto-repair invalid JSON escapes in LLM tool-call arguments

### DIFF
--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -543,9 +543,7 @@ export async function generate(
             return {
               id: it.id,
               input:
-                it.function.arguments.trim() === ""
-                  ? {}
-                  : (parseRepairedJSON(it.function.arguments) as Record<string, unknown>),
+                it.function.arguments.trim() === "" ? {} : parseRepairedJSON(it.function.arguments),
               name: it.function.name,
               type: "toolCall",
             } as ToolCallContent;

--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { KeyPool } from "@cireilclaw/sdk";
 import { toJsonSchema } from "@valibot/to-json-schema";
 import { OpenAI } from "openai/client.js";
@@ -548,8 +550,12 @@ export async function generate(
               type: "toolCall",
             } as ToolCallContent;
           } catch (error: unknown) {
+            const hash = createHash("sha256")
+              .update(it.function.arguments)
+              .digest("hex")
+              .slice(0, 8);
             throw new Error(
-              `Failed to parse tool-call arguments into a json object\n ${it.function.arguments}`,
+              `Failed to parse tool-call arguments: length=${it.function.arguments.length} hash=${hash}`,
               { cause: error },
             );
           }

--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -20,6 +20,7 @@ import type { Tool } from "#engine/tool.js";
 import { debug, warning } from "#output/log.js";
 import { encode } from "#util/base64.js";
 import { toJpeg } from "#util/image.js";
+import { parseRepairedJSON } from "#util/json.js";
 
 // Per-apiBase JPEG requirement flag. Set on first WebP rejection so subsequent
 // turns skip the doomed WebP attempt entirely.
@@ -541,7 +542,10 @@ export async function generate(
           try {
             return {
               id: it.id,
-              input: it.function.arguments.trim() === "" ? {} : JSON.parse(it.function.arguments),
+              input:
+                it.function.arguments.trim() === ""
+                  ? {}
+                  : (parseRepairedJSON(it.function.arguments) as Record<string, unknown>),
               name: it.function.name,
               type: "toolCall",
             } as ToolCallContent;

--- a/packages/runtime/src/engine/provider/openai-codex.ts
+++ b/packages/runtime/src/engine/provider/openai-codex.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { toJsonSchema } from "@valibot/to-json-schema";
 import * as vb from "valibot";
 
@@ -559,21 +561,36 @@ function translateCodexOutput(
         }),
         item,
       );
-      try {
+      const argsJson = parsed.arguments.trim();
+      if (argsJson.length === 0) {
         toolCalls.push({
           id: parsed.call_id,
-          input:
-            parsed.arguments.trim().length === 0
-              ? {}
-              : (parseRepairedJSON(parsed.arguments) as Record<string, unknown>),
+          input: {},
           name: parsed.name,
           type: "toolCall",
         });
-      } catch (error: unknown) {
-        throw new Error(
-          `Failed to parse tool-call arguments into a json object\n ${parsed.arguments}`,
-          { cause: error },
-        );
+      } else {
+        try {
+          const result = parseRepairedJSON(argsJson);
+          if (typeof result !== "object" || result === null || Array.isArray(result)) {
+            const hash = createHash("sha256").update(argsJson).digest("hex").slice(0, 8);
+            throw new Error(
+              `Tool-call arguments parsed to non-object: length=${argsJson.length} hash=${hash}`,
+            );
+          }
+          toolCalls.push({
+            id: parsed.call_id,
+            input: result,
+            name: parsed.name,
+            type: "toolCall",
+          });
+        } catch (error: unknown) {
+          const hash = createHash("sha256").update(argsJson).digest("hex").slice(0, 8);
+          throw new Error(
+            `Failed to parse tool-call arguments: length=${argsJson.length} hash=${hash}`,
+            { cause: error },
+          );
+        }
       }
     } else if (type === "reasoning") {
       const encrypted = item["encrypted_content"];

--- a/packages/runtime/src/engine/provider/openai-codex.ts
+++ b/packages/runtime/src/engine/provider/openai-codex.ts
@@ -9,6 +9,7 @@ import type { Tool } from "#engine/tool.js";
 import { debug, warning } from "#output/log.js";
 import { encode } from "#util/base64.js";
 import { toJpeg } from "#util/image.js";
+import { parseRepairedJSON } from "#util/json.js";
 
 import { getChatGptAccountId, getValidCodexAuth } from "./openai-codex-auth.js";
 
@@ -558,12 +559,22 @@ function translateCodexOutput(
         }),
         item,
       );
-      toolCalls.push({
-        id: parsed.call_id,
-        input: parsed.arguments.trim().length === 0 ? {} : JSON.parse(parsed.arguments),
-        name: parsed.name,
-        type: "toolCall",
-      });
+      try {
+        toolCalls.push({
+          id: parsed.call_id,
+          input:
+            parsed.arguments.trim().length === 0
+              ? {}
+              : (parseRepairedJSON(parsed.arguments) as Record<string, unknown>),
+          name: parsed.name,
+          type: "toolCall",
+        });
+      } catch (error: unknown) {
+        throw new Error(
+          `Failed to parse tool-call arguments into a json object\n ${parsed.arguments}`,
+          { cause: error },
+        );
+      }
     } else if (type === "reasoning") {
       const encrypted = item["encrypted_content"];
       if (typeof encrypted === "string" && encrypted.length > 0) {

--- a/packages/runtime/src/util/json.test.ts
+++ b/packages/runtime/src/util/json.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseRepairedJSON, repairJsonEscapes } from "./json.js";
+import { parseRepairedJSON, repairJsonEscapes } from "#util/json.js";
 
 describe("repairJsonEscapes", () => {
   it("passes valid JSON through unchanged", () => {

--- a/packages/runtime/src/util/json.test.ts
+++ b/packages/runtime/src/util/json.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRepairedJSON, repairJsonEscapes } from "./json.js";
+
+describe("repairJsonEscapes", () => {
+  it("passes valid JSON through unchanged", () => {
+    const valid = '{"key": "value"}';
+    expect(repairJsonEscapes(valid)).toBe(valid);
+  });
+
+  it(String.raw`preserves valid JSON escape \\`, () => {
+    const input = String.raw`{"pattern": "\\d"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+    expect(JSON.parse(repairJsonEscapes(input))).toEqual({ pattern: "\\d" });
+  });
+
+  it(String.raw`preserves valid JSON escape \"`, () => {
+    const input = String.raw`{"key": "he\"llo"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+    expect(JSON.parse(repairJsonEscapes(input))).toEqual({ key: 'he"llo' });
+  });
+
+  it(String.raw`preserves valid JSON escape \n`, () => {
+    const input = String.raw`{"key": "line1\nline2"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+    expect(JSON.parse(repairJsonEscapes(input))).toEqual({ key: "line1\nline2" });
+  });
+
+  it(String.raw`preserves valid JSON escape \t`, () => {
+    const input = String.raw`{"key": "col1\tcol2"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+  });
+
+  it(String.raw`preserves valid JSON escape \/`, () => {
+    const input = String.raw`{"url": "https:\/\/example.com"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+  });
+
+  it(String.raw`preserves valid JSON escape \uXXXX`, () => {
+    const input = String.raw`{"key": "\u0041"}`;
+    expect(repairJsonEscapes(input)).toBe(input);
+    expect(JSON.parse(repairJsonEscapes(input))).toEqual({ key: "A" });
+  });
+
+  it(String.raw`repairs \| to \\|`, () => {
+    const input = String.raw`{"pattern": "not.*but\|is not"}`;
+    const repaired = repairJsonEscapes(input);
+    expect(repaired).toBe(String.raw`{"pattern": "not.*but\\|is not"}`);
+    expect(JSON.parse(repaired)).toEqual({ pattern: "not.*but\\|is not" });
+  });
+
+  it(String.raw`repairs \s to \\s (regex whitespace)`, () => {
+    const raw = String.raw`{"pattern": "\s+word"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    expect(repaired).toBe(String.raw`{"pattern": "\\s+word"}`);
+    expect(JSON.parse(repaired)).toEqual({ pattern: "\\s+word" });
+  });
+
+  it(String.raw`repairs \( to \\( (regex group)`, () => {
+    const raw = String.raw`{"pattern": "\(group\)"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    expect(JSON.parse(repaired)).toEqual({ pattern: "\\(group\\)" });
+  });
+
+  it("repairs the exact error case from grep arguments", () => {
+    const raw = String.raw`{"command": "grep", "args": ["-n","-i","not.*but\|isn't.*it's\|is not.*it is","file.md"]}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    const parsed = JSON.parse(repaired);
+    expect(parsed).toEqual({
+      args: ["-n", "-i", String.raw`not.*but\|isn't.*it's\|is not.*it is`, "file.md"],
+      command: "grep",
+    });
+  });
+
+  it(String.raw`repairs \d to \\d (regex digit)`, () => {
+    const raw = String.raw`{"pattern": "\d+"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    expect(JSON.parse(repaired)).toEqual({ pattern: "\\d+" });
+  });
+
+  it(String.raw`repairs \w to \\w (regex word)`, () => {
+    const raw = String.raw`{"pattern": "\w+"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    expect(JSON.parse(repaired)).toEqual({ pattern: "\\w+" });
+  });
+
+  it("does not crash on a trailing backslash before end of input", () => {
+    // The JSON is truncated: {"key": "trailing\  (no closing quote)
+    // repairJsonEscapes escapes the dangling backslash but the result is
+    // still invalid JSON (unterminated string). Verify it doesn't crash.
+    const raw = '{"key": "trailing\\';
+    const repaired = repairJsonEscapes(raw);
+    expect(repaired).toBe(String.raw`{"key": "trailing\\`);
+    expect(() => JSON.parse(repaired)).toThrow();
+  });
+
+  it(String.raw`preserves already-correct \\|`, () => {
+    const raw = String.raw`{"pattern": "\\|"}`;
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(JSON.parse(raw)).toEqual({ pattern: "\\|" });
+    expect(repairJsonEscapes(raw)).toBe(raw);
+  });
+
+  it("handles mixed valid and invalid escapes", () => {
+    const raw = String.raw`{"a": "\n\t", "b": "\|"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+    const repaired = repairJsonEscapes(raw);
+    const parsed = JSON.parse(repaired);
+    expect(parsed).toEqual({ a: "\n\t", b: "\\|" });
+  });
+
+  it("is a no-op on valid JSON with no escapes", () => {
+    const input = '{"key": "simple value", "num": 42}';
+    expect(repairJsonEscapes(input)).toBe(input);
+  });
+
+  it("handles empty string", () => {
+    expect(repairJsonEscapes("")).toBe("");
+  });
+});
+
+describe("parseRepairedJSON", () => {
+  it("parses valid JSON normally", () => {
+    expect(parseRepairedJSON('{"key": "value"}')).toEqual({ key: "value" });
+  });
+
+  it("repairs and parses invalid JSON with bad escapes", () => {
+    const raw = String.raw`{"pattern": "\s+"}`;
+    expect(parseRepairedJSON(raw)).toEqual({ pattern: "\\s+" });
+  });
+
+  it("throws original error when repair also fails", () => {
+    expect(() => parseRepairedJSON("not json at all {")).toThrow(SyntaxError);
+  });
+
+  it("handles empty object", () => {
+    expect(parseRepairedJSON("{}")).toEqual({});
+  });
+
+  it("handles escaped quotes in repaired content", () => {
+    const raw = String.raw`{"key": "he\"llo \| world"}`;
+    expect(parseRepairedJSON(raw)).toEqual({ key: 'he"llo \\| world' });
+  });
+});

--- a/packages/runtime/src/util/json.test.ts
+++ b/packages/runtime/src/util/json.test.ts
@@ -51,7 +51,9 @@ describe("repairJsonEscapes", () => {
 
   it(String.raw`repairs \s to \\s (regex whitespace)`, () => {
     const raw = String.raw`{"pattern": "\s+word"}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
     expect(repaired).toBe(String.raw`{"pattern": "\\s+word"}`);
     expect(JSON.parse(repaired)).toEqual({ pattern: "\\s+word" });
@@ -59,16 +61,20 @@ describe("repairJsonEscapes", () => {
 
   it(String.raw`repairs \( to \\( (regex group)`, () => {
     const raw = String.raw`{"pattern": "\(group\)"}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
     expect(JSON.parse(repaired)).toEqual({ pattern: "\\(group\\)" });
   });
 
   it("repairs the exact error case from grep arguments", () => {
     const raw = String.raw`{"command": "grep", "args": ["-n","-i","not.*but\|isn't.*it's\|is not.*it is","file.md"]}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
-    const parsed = JSON.parse(repaired);
+    const parsed: unknown = JSON.parse(repaired);
     expect(parsed).toEqual({
       args: ["-n", "-i", String.raw`not.*but\|isn't.*it's\|is not.*it is`, "file.md"],
       command: "grep",
@@ -77,14 +83,18 @@ describe("repairJsonEscapes", () => {
 
   it(String.raw`repairs \d to \\d (regex digit)`, () => {
     const raw = String.raw`{"pattern": "\d+"}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
     expect(JSON.parse(repaired)).toEqual({ pattern: "\\d+" });
   });
 
   it(String.raw`repairs \w to \\w (regex word)`, () => {
     const raw = String.raw`{"pattern": "\w+"}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
     expect(JSON.parse(repaired)).toEqual({ pattern: "\\w+" });
   });
@@ -96,21 +106,28 @@ describe("repairJsonEscapes", () => {
     const raw = '{"key": "trailing\\';
     const repaired = repairJsonEscapes(raw);
     expect(repaired).toBe(String.raw`{"key": "trailing\\`);
-    expect(() => JSON.parse(repaired)).toThrow();
+    expect(() => {
+      JSON.parse(repaired);
+    }).toThrow();
   });
 
   it(String.raw`preserves already-correct \\|`, () => {
     const raw = String.raw`{"pattern": "\\|"}`;
-    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).not.toThrow();
     expect(JSON.parse(raw)).toEqual({ pattern: "\\|" });
     expect(repairJsonEscapes(raw)).toBe(raw);
   });
 
   it("handles mixed valid and invalid escapes", () => {
     const raw = String.raw`{"a": "\n\t", "b": "\|"}`;
-    expect(() => JSON.parse(raw)).toThrow();
+    expect(() => {
+      JSON.parse(raw);
+    }).toThrow();
     const repaired = repairJsonEscapes(raw);
-    const parsed = JSON.parse(repaired);
+    const parsed: unknown = JSON.parse(repaired);
+    // oxlint-disable-next-line id-length
     expect(parsed).toEqual({ a: "\n\t", b: "\\|" });
   });
 

--- a/packages/runtime/src/util/json.ts
+++ b/packages/runtime/src/util/json.ts
@@ -1,0 +1,77 @@
+// oxlint-disable id-length
+const VALID_JSON_ESCAPE_CHARS: Record<string, true> = {
+  '"': true,
+  "/": true,
+  "\\": true,
+  b: true,
+  f: true,
+  n: true,
+  r: true,
+  t: true,
+  u: true,
+};
+// oxlint-enable id-length
+
+/**
+ * Repair invalid JSON escape sequences in a string by doubling backslashes
+ * that precede characters not recognized as valid JSON escape sequences.
+ *
+ * LLMs sometimes emit tool-call arguments with regex patterns containing
+ * unescaped backslashes (e.g. `\|`, `\s`, `\(`). These are invalid JSON.
+ * This function converts them to properly escaped `\\|`, `\\s`, `\\(`, etc.
+ *
+ * Valid JSON escapes (`\\`, `\"`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`,
+ * `\uXXXX`) are left untouched. Already-escaped backslashes (`\\`) are
+ * recognized and preserved.
+ *
+ * This is a no-op on valid JSON.
+ */
+function repairJsonEscapes(json: string): string {
+  const parts: string[] = [];
+  // oxlint-disable id-length
+  let i = 0;
+  // oxlint-enable id-length
+
+  while (i < json.length) {
+    const ch = json.charAt(i);
+    if (ch === "\\") {
+      const next = json[i + 1];
+      if (next !== undefined && VALID_JSON_ESCAPE_CHARS[next] !== undefined) {
+        // Valid JSON escape — pass through unchanged.
+        parts.push("\\", next);
+        i += 2;
+      } else {
+        // Invalid or trailing backslash — insert an extra backslash.
+        parts.push(String.raw`\\`);
+        if (next !== undefined) {
+          parts.push(next);
+        }
+        i += next === undefined ? 1 : 2;
+      }
+    } else {
+      parts.push(ch);
+      i += 1;
+    }
+  }
+
+  return parts.join("");
+}
+
+/**
+ * Attempt to parse a JSON string, repairing invalid escape sequences if the
+ * initial parse fails. Returns the parsed value on success, or throws the
+ * original SyntaxError if repair also fails.
+ */
+function parseRepairedJSON(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch (originalError) {
+    try {
+      return JSON.parse(repairJsonEscapes(json));
+    } catch {
+      throw originalError;
+    }
+  }
+}
+
+export { parseRepairedJSON, repairJsonEscapes };

--- a/packages/runtime/src/util/json.ts
+++ b/packages/runtime/src/util/json.ts
@@ -8,9 +8,10 @@ const VALID_JSON_ESCAPE_CHARS: Record<string, true> = {
   n: true,
   r: true,
   t: true,
-  u: true,
 };
 // oxlint-enable id-length
+
+const HEX_DIGIT = /^[0-9A-Fa-f]$/u;
 
 /**
  * Repair invalid JSON escape sequences in a string by doubling backslashes
@@ -36,17 +37,40 @@ function repairJsonEscapes(json: string): string {
     const ch = json.charAt(i);
     if (ch === "\\") {
       const next = json[i + 1];
-      if (next !== undefined && VALID_JSON_ESCAPE_CHARS[next] !== undefined) {
+      if (next === undefined) {
+        // Trailing backslash at end of input — escape it.
+        parts.push(String.raw`\\`);
+        i += 1;
+      } else if (next === "u") {
+        // \uXXXX — only valid if followed by exactly 4 hex digits.
+        if (
+          HEX_DIGIT.test(json.charAt(i + 2)) &&
+          HEX_DIGIT.test(json.charAt(i + 3)) &&
+          HEX_DIGIT.test(json.charAt(i + 4)) &&
+          HEX_DIGIT.test(json.charAt(i + 5))
+        ) {
+          parts.push(
+            "\\",
+            "u",
+            json.charAt(i + 2),
+            json.charAt(i + 3),
+            json.charAt(i + 4),
+            json.charAt(i + 5),
+          );
+          i += 6;
+        } else {
+          // Malformed \u — escape the backslash.
+          parts.push(String.raw`\\`, "u");
+          i += 2;
+        }
+      } else if (VALID_JSON_ESCAPE_CHARS[next] === undefined) {
+        // Invalid escape — insert an extra backslash.
+        parts.push(String.raw`\\`, next);
+        i += 2;
+      } else {
         // Valid JSON escape — pass through unchanged.
         parts.push("\\", next);
         i += 2;
-      } else {
-        // Invalid or trailing backslash — insert an extra backslash.
-        parts.push(String.raw`\\`);
-        if (next !== undefined) {
-          parts.push(next);
-        }
-        i += next === undefined ? 1 : 2;
       }
     } else {
       parts.push(ch);


### PR DESCRIPTION
## Problem

LLMs sometimes emit tool-call arguments with regex patterns containing unescaped backslashes (e.g. `\|`, `\s`, `\(`). These are invalid JSON and cause parse failures like:

```
[ WARN] Error during agent turn: Failed to parse tool-call arguments into a json object
 {"command": "grep", "args": ["-n","-i","not.*but\|isn't.*it's\|is not.*it is",...]}
```

## Fix

- **`util/json.ts`** — `repairJsonEscapes()` doubles backslashes before non-standard JSON escape characters while preserving already-valid escapes (`\\`, `\"`, `\n`, `\uXXXX`) and already-correct `\\|`. `parseRepairedJSON()` wraps `JSON.parse` with a repair fallback.
- **`provider/oai.ts`** — Uses `parseRepairedJSON` at the tool-call arguments parse site.
- **`provider/openai-codex.ts`** — Same, plus added missing try/catch with descriptive error message.

23 unit tests covering valid escapes preserved, invalid escapes repaired, the exact grep-argument error case, and edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security-Critical Observations

**Input Transformation in Parsing Pipeline**
- The PR adds util/repairJsonEscapes() and parseRepairedJSON(), which automatically modify LLM-provided tool-call arguments by doubling backslashes before non-standard JSON escape characters (e.g., converting `\|` → `\\|`) to make the JSON parseable. This is a behavioral change in the Parsing and Validation subsystem: inputs are repaired silently and accepted even if the original LLM output contained invalid JSON escapes. The repair is conservative (preserves standard JSON escapes and validates `\uXXXX`) but can mask malformed or unexpected inputs without audit logging.

**Retry and Error Semantics**
- parseRepairedJSON() tries JSON.parse(raw) first, and only if that throws it attempts JSON.parse(repairJsonEscapes(raw)). If the repair attempt also fails, the function rethrows the original SyntaxError from the first parse attempt (so callers see the original parse failure rather than a secondary error). This preserves original failure semantics when repair cannot help.

**Provider Behavior & Validation Asymmetry**
- provider/openai-codex.ts: uses parseRepairedJSON and adds explicit validation that parsed tool-call arguments are an object (rejects arrays and null), throwing a descriptive Error that includes arguments length and an 8-char SHA-256 fingerprint (and sets the original parse error as cause). This strengthens type validation and avoids accepting unexpected structures.
- provider/oai.ts: now uses parseRepairedJSON too and also replaces embedding raw arguments in the thrown error with a length + SHA-256 fingerprint. However, unlike openai-codex.ts, oai.ts does not perform the same explicit runtime check that the parsed value is an object (vs. array/null). This asymmetry could produce different failure modes between providers and should be harmonized if uniform behavior is desired.

**Error Message Sanitization**
- Both providers stop including raw argument payloads in error messages and instead include the payload length and a short SHA-256 hash. This reduces risk of leaking sensitive or large data in logs, at the expense of less immediate debugging context.

**Scope & Limitations of Repair**
- The repair targets invalid escape sequences (common in regex-like arguments) by doubling backslashes; it does not attempt to fix structural JSON corruption beyond escape sequences (e.g., truncated strings or other syntax errors remain unrepairable). Edge cases covered by tests include dangling trailing backslashes (left invalid) and malformed `\u` sequences (leading `\` is escaped instead of being treated as a valid `\u`).

**Tests and Public API**
- 23 unit tests were added (packages/runtime/src/util/json.test.ts) covering preservation of valid escapes, repair of invalid escapes (including a grep-like example), error rethrow behavior when repair fails, and several edge cases.
- New exports introduced in packages/runtime/src/util/json.ts:
  - repairJsonEscapes(json: string): string
  - parseRepairedJSON(json: string): unknown

No other public/exported signatures were changed.

## Recommendations / Points to Review
- Consider adding the same object-structure validation to oai.ts to keep provider behavior consistent.
- Consider adding logging or an opt-in audit trail for repaired inputs so repairs are visible in diagnostics (helps incident investigation while retaining sanitization).
- Review downstream consumers to ensure repaired-but-different inputs do not create semantic or security issues (e.g., changed regexes or commands).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->