### PR TITLE
Support detecting pings better than before

### DIFF
--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -145,7 +145,10 @@ async function resolveDisplayName(msg: DiscordMessage): Promise<string> {
 // agent has full context about who sent what and when, without needing to
 // parse it out of the message history separately. Includes attachment metadata
 // so the model knows what files/images are present.
-async function formatUserMessage(msg: DiscordMessage): Promise<TextContent> {
+async function formatUserMessage(
+  msg: DiscordMessage,
+  opts?: { directReply?: DiscordMessage; isMentioned?: boolean },
+): Promise<TextContent> {
   const { username } = msg.author;
   const authorId = msg.author.id;
   const displayName = await resolveDisplayName(msg);
@@ -177,8 +180,22 @@ async function formatUserMessage(msg: DiscordMessage): Promise<TextContent> {
     innerContent += `\n${stickerInfo}`;
   }
 
+  // Build optional attributes for reply/mention context
+  let replyAttr = "";
+  if (opts?.directReply !== undefined) {
+    const isReplyingToBot = opts.directReply.author.id === msg.client.application.id;
+    if (isReplyingToBot) {
+      replyAttr = ` in-reply-to="YOU"`;
+    } else {
+      const replyDisplayName = await resolveDisplayName(opts.directReply);
+      replyAttr = ` in-reply-to="${replyDisplayName}"`;
+    }
+  }
+
+  const mentionAttr = (opts?.isMentioned ?? false) ? ` mentions="YOU"` : "";
+
   return {
-    content: `<msg msgId="${msg.id}" from="${username} <${authorId}>" displayName="${displayName}" timestamp="${timestamp}">${innerContent}</msg>`,
+    content: `<msg msgId="${msg.id}" from="${username} <${authorId}>" displayName="${displayName}" timestamp="${timestamp}"${replyAttr}${mentionAttr}>${innerContent}</msg>`,
     type: "text",
   };
 }
@@ -796,7 +813,10 @@ async function handleMessageCreate(
       }
     }
 
-    const textContent = await formatUserMessage(msg);
+    const textContent = await formatUserMessage(msg, {
+      directReply,
+      isMentioned: memberIdMentioned || userIdMentioned,
+    });
     const imageContents = await fetchAllImages(msg);
 
     const engineConfig = await loadEngine(agentSlug);


### PR DESCRIPTION
Injects additional context into incoming messages about whether the agent was mentioned specifically or not. Or whether it was a reply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Additional Implementation Details

The PR modifies `formatUserMessage` to accept optional context about reply relationships and mentions. When a `directReply` is provided, the function constructs an `in-reply-to` attribute that references either "YOU" (if the replied-to message was from the bot) or the display name of the original author. The mention detection is computed in `handleMessageCreate` by checking if the bot's application ID appears in either the members or users mention arrays.

The contextual metadata is embedded directly into the XML-like message tag format that is sent to the AI model, allowing the model to understand conversation context without needing to parse it from message history.

## Security Consideration: XML Attribute Value Injection

The implementation embeds user-controlled values directly into XML attributes without escaping:
- `displayName` values (derived from guild nicknames, global names, or usernames) are inserted into the `displayName` attribute
- `replyDisplayName` values are inserted into the `in-reply-to` attribute without XML entity encoding

While the generated XML is consumed by an AI model rather than rendered as HTML, unescaped special characters (quotes, angle brackets, ampersands) in usernames or nicknames could potentially malform the XML structure or enable prompt injection attacks. This issue existed prior to this PR but is not addressed by these changes. The PR should either implement proper XML entity escaping or document this as a known limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->