### PR TITLE
chore: upgrade deps, fix all new lints

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,6 +25,7 @@
     }
   ],
   "rules": {
+    "eslint/prefer-named-capture-group": "off",
     "eslint/no-useless-assignment": "off",
     "import/no-named-export": "off",
     "import/no-relative-parent-imports": "off",
@@ -57,6 +58,13 @@
     "unicorn/prefer-ternary": "off",
     "unicorn/prefer-event-target": "off",
     "unicorn/no-useless-undefined": "off",
+    "typescript/method-signature-style": ["warn", "method"],
+    "typescript/no-invalid-void-type": [
+      "warn",
+      {
+        "allowAsThisParameter": true
+      }
+    ],
     "eslint/no-console": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "format:check": "oxfmt --check ."
   },
   "devDependencies": {
-    "oxfmt": "^0.46.0",
-    "oxlint": "^1.61.0",
-    "oxlint-tsgolint": "^0.21.1",
+    "oxfmt": "^0.53.0",
+    "oxlint": "^1.68.0",
+    "oxlint-tsgolint": "^0.23.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -13,15 +13,15 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
     },
-    "main": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@cireilclaw/sdk": "workspace:*",
-    "tsdown": "^0.21.10",
+    "tsdown": "^0.22.1",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/openweather/package.json
+++ b/packages/openweather/package.json
@@ -13,15 +13,15 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
     },
-    "main": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@cireilclaw/sdk": "workspace:*",
-    "tsdown": "^0.21.10",
+    "tsdown": "^0.22.1",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@cireilclaw/sdk": "workspace:*",
-    "@inquirer/prompts": "^8.4.2",
+    "@inquirer/prompts": "^8.5.2",
     "@noble/hashes": "^2.2.0",
     "@stricli/core": "^1.2.6",
     "@valibot/to-json-schema": "^1.6.0",
@@ -24,26 +24,28 @@
     "croner": "^10.0.1",
     "drizzle-orm": "1.0.0-beta.20",
     "heic-decode": "^2.1.0",
-    "ink": "^7.0.1",
+    "ink": "^7.0.5",
     "ink-multiline-input": "^0.1.0",
     "ink-spinner": "^5.0.0",
     "oceanic.js": "^1.14.0",
-    "openai": "^6.34.0",
+    "openai": "^6.42.0",
     "ora": "^9.4.0",
-    "react": "^19.2.5",
+    "react": "^19.2.7",
     "sharp": "^0.34.5",
     "smol-toml": "^1.6.1",
-    "valibot": "^1.3.1",
+    "valibot": "^1.4.1",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/heic-decode": "^1.1.3",
+    "@types/heic-decode": "^2.0.0",
     "@types/node": "^25.6.0",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.16",
     "drizzle-kit": "1.0.0-beta.20",
-    "tsx": "^4.21.0",
+    "node-addon-api": "^8.8.0",
+    "node-gyp": "^12.3.0",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -15,13 +15,13 @@ import { DiscordSession, NamedInternalSession, TuiSession } from "#harness/sessi
 import { Scheduler } from "#scheduler/index.js";
 
 export class Agent {
-  private readonly _slug: string;
-  private readonly _sessions: Map<string, Session>;
-  private readonly _channelHandlers = new Map<string, ChannelHandler>();
-  private _conditions: ConditionsConfig;
-  private _discordClient?: OceanicClient;
-  private _ownerId?: string;
-  private readonly _scheduler?: Scheduler;
+  public readonly slug: string;
+  public readonly sessions: Map<string, Session>;
+  public readonly channelHandlers = new Map<string, ChannelHandler>();
+  public conditions: ConditionsConfig;
+  public discordClient?: OceanicClient;
+  public ownerId?: string;
+  public readonly scheduler?: Scheduler;
 
   public constructor(
     slug: string,
@@ -29,53 +29,21 @@ export class Agent {
     signal?: AbortSignal,
     conditions?: ConditionsConfig,
   ) {
-    this._slug = slug;
-    this._sessions = sessions;
-    this._conditions = conditions ?? { blocks: {}, memories: {}, workspace: {} };
+    this.slug = slug;
+    this.sessions = sessions;
+    this.conditions = conditions ?? { blocks: {}, memories: {}, workspace: {} };
 
     if (signal !== undefined) {
-      this._scheduler = new Scheduler(this, signal);
+      this.scheduler = new Scheduler(this, signal);
     }
   }
 
   public async updateConditions(): Promise<void> {
-    this._conditions = await loadConditions(this._slug);
-  }
-
-  public get conditions(): ConditionsConfig {
-    return this._conditions;
-  }
-
-  public get slug(): string {
-    return this._slug;
-  }
-
-  public get scheduler(): Scheduler | undefined {
-    return this._scheduler;
-  }
-
-  public get sessions(): Map<string, Session> {
-    return this._sessions;
-  }
-
-  public setDiscordClient(client: OceanicClient): void {
-    this._discordClient = client;
-  }
-
-  public get discordClient(): OceanicClient | undefined {
-    return this._discordClient;
-  }
-
-  public setOwnerId(ownerId: string): void {
-    this._ownerId = ownerId;
-  }
-
-  public get ownerId(): string | undefined {
-    return this._ownerId;
+    this.conditions = await loadConditions(this.slug);
   }
 
   public registerChannel(channel: string, handler: ChannelHandler): void {
-    this._channelHandlers.set(channel, handler);
+    this.channelHandlers.set(channel, handler);
   }
 
   public async resolveTarget(target: string): Promise<Session | undefined> {
@@ -85,7 +53,7 @@ export class Agent {
 
     if (target === "last") {
       let best: Session | undefined = undefined;
-      for (const session of this._sessions.values()) {
+      for (const session of this.sessions.values()) {
         if (best === undefined || session.lastActivity > best.lastActivity) {
           best = session;
         }
@@ -93,20 +61,20 @@ export class Agent {
       return best;
     }
 
-    const existing = this._sessions.get(target);
+    const existing = this.sessions.get(target);
     if (existing !== undefined) {
       return existing;
     }
 
     if (target.startsWith("internal:")) {
       const session = new NamedInternalSession(target.slice("internal:".length));
-      this._sessions.set(target, session);
+      this.sessions.set(target, session);
       return session;
     }
 
     if (target === "tui") {
       const session = new TuiSession();
-      this._sessions.set(target, session);
+      this.sessions.set(target, session);
       return session;
     }
 
@@ -118,20 +86,20 @@ export class Agent {
           channelId,
           guildId: guildId ?? undefined,
         });
-        this._sessions.set(target, session);
+        this.sessions.set(target, session);
         return session;
       }
     }
 
     if (target === "owner") {
-      if (this._ownerId === undefined || this._discordClient === undefined) {
+      if (this.ownerId === undefined || this.discordClient === undefined) {
         return undefined;
       }
 
       try {
-        const dmChannel = await this._discordClient.rest.users.createDM(this._ownerId);
+        const dmChannel = await this.discordClient.rest.users.createDM(this.ownerId);
         const sessionId = `discord:${dmChannel.id}`;
-        const prior = this._sessions.get(sessionId);
+        const prior = this.sessions.get(sessionId);
         if (prior !== undefined) {
           return prior;
         }
@@ -139,7 +107,7 @@ export class Agent {
         const session = new DiscordSession({
           channelId: dmChannel.id,
         });
-        this._sessions.set(sessionId, session);
+        this.sessions.set(sessionId, session);
         return session;
       } catch {
         return undefined;
@@ -149,8 +117,8 @@ export class Agent {
     return undefined;
   }
 
-  private _getHandler(session: Session): ChannelHandler {
-    return this._channelHandlers.get(session.channel) ?? MINIMAL_HANDLER;
+  private getHandler(session: Session): ChannelHandler {
+    return this.channelHandlers.get(session.channel) ?? MINIMAL_HANDLER;
   }
 
   public async send(
@@ -163,7 +131,7 @@ export class Agent {
       return;
     }
 
-    const handler = this._getHandler(session);
+    const handler = this.getHandler(session);
     await handler.send(session, content, attachments, flags);
   }
 
@@ -175,7 +143,7 @@ export class Agent {
 
     if (spec === "last") {
       let best: Session | undefined = undefined;
-      for (const session of this._sessions.values()) {
+      for (const session of this.sessions.values()) {
         if (best === undefined || session.lastActivity > best.lastActivity) {
           best = session;
         }
@@ -183,17 +151,17 @@ export class Agent {
       return best ?? { error: "no active sessions found" };
     }
 
-    const handler = this._getHandler(currentSession);
+    const handler = this.getHandler(currentSession);
     if (handler.resolveChannel !== undefined) {
-      const result = handler.resolveChannel(spec, this._sessions, this._ownerId);
+      const result = handler.resolveChannel(spec, this.sessions, this.ownerId);
       return result;
     }
 
-    return this._sessions.get(spec) ?? { error: `session not found: ${spec}` };
+    return this.sessions.get(spec) ?? { error: `session not found: ${spec}` };
   }
 
   public async runTurn(session: Session): Promise<void> {
-    const handler = this._getHandler(session);
+    const handler = this.getHandler(session);
 
     const send = async (content: string, attachments?: string[]): Promise<void> => {
       await this.send(session, content, attachments);
@@ -240,7 +208,7 @@ export class Agent {
 
     await runTurn(
       session,
-      this._slug,
+      this.slug,
       {},
       send,
       sendTo,
@@ -249,7 +217,7 @@ export class Agent {
       fetchHistory,
       resolveChannel,
       handler.capabilities,
-      this._conditions,
+      this.conditions,
     );
   }
 }

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { basename, join } from "node:path";
+import path from "node:path";
 
 import type {
   AnyInteractionGateway,
@@ -99,7 +99,7 @@ const AUTOCOMPLETE_HANDLERS = new Map<string, AutocompleteHandler>([
 const COMMANDS_HASH = createHash("sha256").update(JSON.stringify(SLASH_COMMANDS)).digest("hex");
 
 function commandsHashFile(agentSlug: string): string {
-  return join(agentRoot(agentSlug), "discord-commands.hash");
+  return path.join(agentRoot(agentSlug), "discord-commands.hash");
 }
 
 function installedCommandsFingerprint(appId: string): string {
@@ -1099,8 +1099,8 @@ async function startDiscord(owner: Harness, agentSlug: string): Promise<OceanicC
   });
 
   // Store client and ownerId on the agent for channel resolution
-  agent.setDiscordClient(client);
-  agent.setOwnerId(ownerId);
+  agent.discordClient = client;
+  agent.ownerId = ownerId;
 
   const discordHandler: ChannelHandler = {
     capabilities: {
@@ -1153,8 +1153,8 @@ async function startDiscord(owner: Harness, agentSlug: string): Promise<OceanicC
           break;
         }
         default: {
-          const _exhaustive: never = direction;
-          throw new Error(`Unknown direction: ${String(_exhaustive)}`);
+          const exhaustive: never = direction;
+          throw new Error(`Unknown direction: ${String(exhaustive)}`);
         }
       }
 
@@ -1227,7 +1227,7 @@ async function startDiscord(owner: Harness, agentSlug: string): Promise<OceanicC
               attachments.map(async (sandboxPath) => {
                 const realPath = sandboxToReal(sandboxPath, agentSlug);
                 const contents = await readFile(realPath);
-                return { contents, name: basename(realPath) };
+                return { contents, name: path.basename(realPath) };
               }),
             )
           : undefined;

--- a/packages/runtime/src/channels/discord/summarize-command.ts
+++ b/packages/runtime/src/channels/discord/summarize-command.ts
@@ -65,8 +65,8 @@ async function handleCommand(interaction: CommandInteraction, ctx: HandlerCtx): 
 
     const slug = name
       .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, "");
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, "");
 
     if (slug.length === 0) {
       await interaction.createFollowup({

--- a/packages/runtime/src/channels/discord/unsummarize-command.ts
+++ b/packages/runtime/src/channels/discord/unsummarize-command.ts
@@ -57,8 +57,8 @@ async function handleCommand(interaction: CommandInteraction, ctx: HandlerCtx): 
 
     const slug = name
       .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, "");
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, "");
 
     let removed = removeSummary(ctx.agentSlug, session, slug);
     let matchedName = name;

--- a/packages/runtime/src/channels/discord/warning-message.ts
+++ b/packages/runtime/src/channels/discord/warning-message.ts
@@ -6,7 +6,7 @@ const DISCORD_WARNING_CONTENT_LIMIT = 1800;
 interface DiscordWarningClient {
   rest: {
     channels: {
-      createMessage: (
+      createMessage(
         channelID: string,
         options: {
           allowedMentions: { repliedUser: true };
@@ -17,7 +17,7 @@ interface DiscordWarningClient {
             messageID: string;
           };
         },
-      ) => Promise<{ createReaction: (emoji: string) => Promise<unknown> }>;
+      ): Promise<{ createReaction(emoji: string): Promise<unknown> }>;
     };
   };
 }

--- a/packages/runtime/src/channels/tui/bridge.ts
+++ b/packages/runtime/src/channels/tui/bridge.ts
@@ -3,14 +3,14 @@ import EventEmitter from "node:events";
 import type { TuiMessage } from "#channels/tui/tui-message.js";
 
 export class TuiBridge extends EventEmitter {
-  private readonly _messages: TuiMessage[] = [];
+  private readonly messages: TuiMessage[] = [];
 
   public push(msg: TuiMessage): void {
-    this._messages.push(msg);
+    this.messages.push(msg);
     this.emit("message", msg);
   }
 
   public snapshot(): TuiMessage[] {
-    return [...this._messages];
+    return [...this.messages];
   }
 }

--- a/packages/runtime/src/cli/codex-command.ts
+++ b/packages/runtime/src/cli/codex-command.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import path from "node:path";
 
 import { input } from "@inquirer/prompts";
 import { buildCommand } from "@stricli/core";
@@ -41,11 +41,11 @@ function commandExists(command: string): boolean {
   }
 
   const pathValue = process.env["PATH"] ?? "";
-  for (const entry of pathValue.split(delimiter)) {
+  for (const entry of pathValue.split(path.delimiter)) {
     if (entry.length === 0) {
       continue;
     }
-    if (existsSync(join(entry, command))) {
+    if (existsSync(path.join(entry, command))) {
       return true;
     }
   }

--- a/packages/runtime/src/cli/index.ts
+++ b/packages/runtime/src/cli/index.ts
@@ -1,13 +1,13 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
 
+import { clearCommand } from "#cli/clear-command.js";
 import { codexCommand } from "#cli/codex-command.js";
+import { initCommand } from "#cli/init-command.js";
+import { migrateCommand } from "#cli/migrate-command.js";
 import { repairCommand } from "#cli/repair-command.js";
 import { runCommand } from "#cli/run-command.js";
 import { tuiCommand } from "#cli/tui-command.js";
 
-import { clearCommand } from "./clear-command.js";
-import { initCommand } from "./init-command.js";
-import { migrateCommand } from "./migrate-command.js";
 const routes = buildRouteMap({
   defaultCommand: "run",
   docs: {

--- a/packages/runtime/src/cli/init-command.ts
+++ b/packages/runtime/src/cli/init-command.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, rename, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { confirm, input, password, select } from "@inquirer/prompts";
 import { buildCommand } from "@stricli/core";
@@ -26,20 +26,20 @@ function slugify(name: string): string {
   return name
     .toLowerCase()
     .trim()
-    .replaceAll(/[^a-z0-9]+/g, "-")
-    .replaceAll(/^-+|-+$/g, "");
+    .replaceAll(/[^a-z0-9]+/gu, "-")
+    .replaceAll(/^-+|-+$/gu, "");
 }
 
-async function renameOld(path: string): Promise<void> {
+async function renameOld(pth: string): Promise<void> {
   let randoms = randomBytes(8).toString("hex");
 
-  while (existsSync(`${path}.${randoms}`)) {
+  while (existsSync(`${pth}.${randoms}`)) {
     randoms = randomBytes(8).toString("hex");
   }
 
-  const dest = `${path}.${randoms}`;
-  await rename(path, dest);
-  warning("Moved", colors.path(path));
+  const dest = `${pth}.${randoms}`;
+  await rename(pth, dest);
+  warning("Moved", colors.path(pth));
   warning("To", colors.path(dest));
 }
 
@@ -344,7 +344,7 @@ async function run(flags: Flags): Promise<void> {
 
   const base = root();
 
-  await mkdir(join(base, "config"), { recursive: true });
+  await mkdir(path.join(base, "config"), { recursive: true });
 
   // Resolve slug before asking anything else so we can catch conflicts early.
   const name = await input({ message: "Agent name:" });
@@ -357,7 +357,7 @@ async function run(flags: Flags): Promise<void> {
   info("Agent slug:", colors.keyword(slug));
 
   // Override check is at the agent level, not the root level.
-  const agentRoot = join(base, "agents", slug);
+  const agentRoot = path.join(base, "agents", slug);
   if (existsSync(agentRoot)) {
     warning("Agent", colors.keyword(slug), "already exists at", colors.path(agentRoot));
     warning(
@@ -499,7 +499,7 @@ async function run(flags: Flags): Promise<void> {
     });
     const ownerId = await input({
       message: "Discord owner ID (your user ID):",
-      validate: (value) => /^[0-9]+$/.test(value) || "Must be a numeric Discord user ID",
+      validate: (value) => /^[0-9]+$/u.test(value) || "Must be a numeric Discord user ID",
     });
     discordConfig = { ownerId, token };
   }
@@ -507,47 +507,51 @@ async function run(flags: Flags): Promise<void> {
   const writeSpinner = ora("Writing agent files...").start();
 
   for (const dir of ["blocks", "config", "memories", "skills", "tasks", "workspace"]) {
-    await mkdir(join(agentRoot, dir), { recursive: true });
+    await mkdir(path.join(agentRoot, dir), { recursive: true });
   }
 
-  await mkdir(join(agentRoot, "skills", "create-skill"), { recursive: true });
-  await writeFile(join(agentRoot, "skills", "create-skill", "SKILL.md"), createSkillStub(), "utf8");
+  await mkdir(path.join(agentRoot, "skills", "create-skill"), { recursive: true });
+  await writeFile(
+    path.join(agentRoot, "skills", "create-skill", "SKILL.md"),
+    createSkillStub(),
+    "utf8",
+  );
 
   for (const label of blockLabels) {
     await writeFile(
-      join(agentRoot, "blocks", `${label}.md`),
+      path.join(agentRoot, "blocks", `${label}.md`),
       blockStub(label, name, description),
       "utf8",
     );
   }
 
-  await writeFile(join(agentRoot, "core.md"), baseInstructionStub(), "utf8");
+  await writeFile(path.join(agentRoot, "core.md"), baseInstructionStub(), "utf8");
   await writeFile(
-    join(agentRoot, "config", "engine.toml"),
+    path.join(agentRoot, "config", "engine.toml"),
     stringify({
       default: { apiBase, apiKey, defaultModel: model, isGlobalDefault: true, kind: apiKind },
     }),
     "utf8",
   );
   await writeFile(
-    join(agentRoot, "config", "tools.toml"),
+    path.join(agentRoot, "config", "tools.toml"),
     stringify(buildToolsConfig(preset, execBinaries)),
     "utf8",
   );
 
   if (braveApiKey !== undefined) {
-    await mkdir(join(base, "config", "plugins"), { recursive: true });
+    await mkdir(path.join(base, "config", "plugins"), { recursive: true });
     await writeFile(
-      join(base, "config", "plugins", "brave-search.toml"),
+      path.join(base, "config", "plugins", "brave-search.toml"),
       stringify({ apiKey: braveApiKey }),
       "utf8",
     );
   }
 
   if (discordConfig !== undefined) {
-    await mkdir(join(agentRoot, "config", "channels"), { recursive: true });
+    await mkdir(path.join(agentRoot, "config", "channels"), { recursive: true });
     await writeFile(
-      join(agentRoot, "config", "channels", "discord.toml"),
+      path.join(agentRoot, "config", "channels", "discord.toml"),
       stringify(discordConfig),
       "utf8",
     );

--- a/packages/runtime/src/cli/repair-command.ts
+++ b/packages/runtime/src/cli/repair-command.ts
@@ -13,7 +13,7 @@ import { fetchSessionDisplayName, repairSession } from "#util/repair-session.js"
 
 // oceanic.js's ESM shim breaks under tsx's module loader (.default.default chain
 // resolves to undefined). Force CJS to get the real constructors.
-// oxlint-disable-next-line typescript/no-unsafe-type-assertions
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const { Client, Intents } = createRequire(import.meta.url)(
   "oceanic.js",
   // oxlint-disable-next-line typescript/consistent-type-imports

--- a/packages/runtime/src/cli/run-command.ts
+++ b/packages/runtime/src/cli/run-command.ts
@@ -1,5 +1,5 @@
 import { watch } from "node:fs/promises";
-import path, { join } from "node:path";
+import path from "node:path";
 
 import { buildCommand } from "@stricli/core";
 
@@ -66,7 +66,7 @@ interface Flags {
 }
 
 async function runWatcher(agentSlug: string, signal: AbortSignal): Promise<void> {
-  const agentDir = join(root(), "agents", agentSlug, "config");
+  const agentDir = path.join(root(), "agents", agentSlug, "config");
   const watcher = watch(agentDir, {
     encoding: "utf8",
     recursive: true,

--- a/packages/runtime/src/config/conditions.ts
+++ b/packages/runtime/src/config/conditions.ts
@@ -10,9 +10,9 @@ const ConditionStringSchema = vb.message(
       (str) =>
         str === "discord:nsfw" ||
         str === "discord:dm" ||
-        /^discord:dm:\d+$/.test(str) ||
-        /^discord:guild:\d+$/.test(str) ||
-        /^discord:channel:\d+$/.test(str) ||
+        /^discord:dm:\d+$/u.test(str) ||
+        /^discord:guild:\d+$/u.test(str) ||
+        /^discord:channel:\d+$/u.test(str) ||
         str === "tui" ||
         str === "internal",
     ),

--- a/packages/runtime/src/config/heartbeat.ts
+++ b/packages/runtime/src/config/heartbeat.ts
@@ -3,8 +3,8 @@ import * as vb from "valibot";
 import { nonEmptyString } from "#config/schemas/shared.js";
 
 const ActiveHoursSchema = vb.strictObject({
-  end: vb.pipe(vb.string(), vb.nonEmpty(), vb.regex(/^\d{2}:\d{2}$/, "Must be HH:MM format")),
-  start: vb.pipe(vb.string(), vb.nonEmpty(), vb.regex(/^\d{2}:\d{2}$/, "Must be HH:MM format")),
+  end: vb.pipe(vb.string(), vb.nonEmpty(), vb.regex(/^\d{2}:\d{2}$/u, "Must be HH:MM format")),
+  start: vb.pipe(vb.string(), vb.nonEmpty(), vb.regex(/^\d{2}:\d{2}$/u, "Must be HH:MM format")),
   timezone: vb.pipe(vb.string(), vb.nonEmpty()),
 });
 

--- a/packages/runtime/src/config/index.ts
+++ b/packages/runtime/src/config/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import type { TomlTable } from "smol-toml";
 import { parse } from "smol-toml";
@@ -26,7 +26,7 @@ import { ToolsConfigSchema } from "./schemas/tools.js";
 import type { ToolsConfig } from "./schemas/tools.js";
 
 async function loadTools(agentSlug: string): Promise<ToolsConfig> {
-  const file = join(root(), "agents", agentSlug, "config", "tools.toml");
+  const file = path.join(root(), "agents", agentSlug, "config", "tools.toml");
 
   if (existsSync(file)) {
     const data = await readFile(file, { encoding: "utf8" });
@@ -41,7 +41,7 @@ async function loadTools(agentSlug: string): Promise<ToolsConfig> {
 async function loadEngine(agentSlug?: string): Promise<ProvidersConfig> {
   let obj: TomlTable | undefined = undefined;
   if (agentSlug === undefined) {
-    const file = join(root(), "config", "engine.toml");
+    const file = path.join(root(), "config", "engine.toml");
 
     if (existsSync(file)) {
       const data = await readFile(file, { encoding: "utf8" });
@@ -51,7 +51,7 @@ async function loadEngine(agentSlug?: string): Promise<ProvidersConfig> {
       throw new Error(`Could not find config file at path: ${colors.path(file)}`);
     }
   } else {
-    const file = join(root(), "agents", agentSlug, "config", "engine.toml");
+    const file = path.join(root(), "agents", agentSlug, "config", "engine.toml");
 
     if (existsSync(file)) {
       const data = await readFile(file, { encoding: "utf8" });
@@ -104,7 +104,7 @@ async function loadChannel<Key extends ChannelType>(
   agentSlug: string,
 ): Promise<ChannelConfigMap[Key]> {
   const origin = root();
-  let path: string | undefined = undefined;
+  let pth: string | undefined = undefined;
   let schema: vb.GenericSchema | undefined = undefined;
 
   // oxlint-disable-next-line typescript/switch-exhaustiveness-check
@@ -117,14 +117,14 @@ async function loadChannel<Key extends ChannelType>(
       throw new Error(`Channel ${channel} is unimplemented.`);
   }
 
-  const maybe = join(origin, "agents", agentSlug, "config", "channels", `${channel}.toml`);
+  const maybe = path.join(origin, "agents", agentSlug, "config", "channels", `${channel}.toml`);
   if (existsSync(maybe)) {
-    path = maybe;
+    pth = maybe;
   } else {
     throw new Error(`No channel config found for ${channel}.`);
   }
 
-  const tomlData = await readFile(path, "utf8");
+  const tomlData = await readFile(pth, "utf8");
   const obj = parse(tomlData);
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
@@ -132,7 +132,7 @@ async function loadChannel<Key extends ChannelType>(
 }
 
 async function loadHeartbeat(agentSlug: string): Promise<HeartbeatConfig> {
-  const file = join(root(), "agents", agentSlug, "config", "heartbeat.toml");
+  const file = path.join(root(), "agents", agentSlug, "config", "heartbeat.toml");
 
   if (!existsSync(file)) {
     return vb.parse(HeartbeatConfigSchema, {});
@@ -145,7 +145,7 @@ async function loadHeartbeat(agentSlug: string): Promise<HeartbeatConfig> {
 }
 
 async function loadCron(agentSlug: string): Promise<CronConfig> {
-  const file = join(root(), "agents", agentSlug, "config", "cron.toml");
+  const file = path.join(root(), "agents", agentSlug, "config", "cron.toml");
 
   if (!existsSync(file)) {
     return vb.parse(CronConfigSchema, {});
@@ -158,7 +158,7 @@ async function loadCron(agentSlug: string): Promise<CronConfig> {
 }
 
 async function loadAgents(): Promise<string[]> {
-  const agentsDir = join(root(), "agents");
+  const agentsDir = path.join(root(), "agents");
 
   if (!existsSync(agentsDir)) {
     return [];
@@ -169,7 +169,7 @@ async function loadAgents(): Promise<string[]> {
 }
 
 async function loadConditions(agentSlug: string): Promise<ConditionsConfig> {
-  const file = join(root(), "agents", agentSlug, "config", "conditions.toml");
+  const file = path.join(root(), "agents", agentSlug, "config", "conditions.toml");
 
   if (!existsSync(file)) {
     return { blocks: {}, memories: {}, workspace: {} };
@@ -184,7 +184,7 @@ async function loadConditions(agentSlug: string): Promise<ConditionsConfig> {
 type SystemConfig = vb.InferOutput<typeof SystemConfigSchema>;
 
 async function loadSystem(): Promise<SystemConfig> {
-  const file = join(root(), "config", "system.toml");
+  const file = path.join(root(), "config", "system.toml");
 
   if (!existsSync(file)) {
     return vb.parse(SystemConfigSchema, {});
@@ -196,19 +196,19 @@ async function loadSystem(): Promise<SystemConfig> {
   return vb.parse(SystemConfigSchema, obj);
 }
 
-function expandTilde(path: string): string {
-  if (path.startsWith("~/")) {
+function expandTilde(pth: string): string {
+  if (pth.startsWith("~/")) {
     const home = process.env["HOME"];
     if (home === undefined) {
       throw new Error("Cannot expand ~ in path: $HOME is not set");
     }
-    return home + path.slice(1);
+    return home + pth.slice(1);
   }
-  return path;
+  return pth;
 }
 
 async function loadSandboxConfig(agentSlug: string): Promise<SandboxConfig> {
-  const file = join(root(), "agents", agentSlug, "config", "sandbox.toml");
+  const file = path.join(root(), "agents", agentSlug, "config", "sandbox.toml");
 
   if (!existsSync(file)) {
     return { mounts: [] };
@@ -234,7 +234,7 @@ async function loadSandboxConfig(agentSlug: string): Promise<SandboxConfig> {
 }
 
 async function loadGlobalPluginConfig(name: string): Promise<Record<string, unknown> | undefined> {
-  const file = join(root(), "config", "plugins", `${name}.toml`);
+  const file = path.join(root(), "config", "plugins", `${name}.toml`);
 
   if (!existsSync(file)) {
     return undefined;
@@ -250,7 +250,7 @@ async function loadAgentPluginConfig(
   agentSlug: string,
   name: string,
 ): Promise<Record<string, unknown> | undefined> {
-  const file = join(root(), "agents", agentSlug, "config", "plugins", `${name}.toml`);
+  const file = path.join(root(), "agents", agentSlug, "config", "plugins", `${name}.toml`);
 
   if (!existsSync(file)) {
     return undefined;

--- a/packages/runtime/src/config/migrations/20260309000000_skills_agentskills_format/migration.ts
+++ b/packages/runtime/src/config/migrations/20260309000000_skills_agentskills_format/migration.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { parse } from "smol-toml";
 
@@ -16,7 +16,7 @@ const migration: ConfigMigration = {
   id: "20260309000000_skills_agentskills_format",
 
   async migrateAgent(_agentSlug, agentPath, context) {
-    const skillsPath = join(agentPath, "skills");
+    const skillsPath = path.join(agentPath, "skills");
 
     if (!existsSync(skillsPath)) {
       return;
@@ -30,7 +30,7 @@ const migration: ConfigMigration = {
       }
 
       const slug = entry.name.slice(0, -3);
-      const flatPath = join(skillsPath, entry.name);
+      const flatPath = path.join(skillsPath, entry.name);
       const content = await readFile(flatPath, "utf8");
 
       if (!content.startsWith("+++")) {
@@ -59,9 +59,9 @@ const migration: ConfigMigration = {
         "",
       ].join("\n");
 
-      const dirPath = join(skillsPath, slug);
+      const dirPath = path.join(skillsPath, slug);
       await mkdir(dirPath, { recursive: true });
-      await writeFile(join(dirPath, "SKILL.md"), yaml + body, "utf8");
+      await writeFile(path.join(dirPath, "SKILL.md"), yaml + body, "utf8");
       await rm(flatPath);
     }
   },

--- a/packages/runtime/src/config/migrations/20260311120000_tasks_folder/migration.ts
+++ b/packages/runtime/src/config/migrations/20260311120000_tasks_folder/migration.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, rename } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import type { ConfigMigration } from "#config/migrations/index.js";
 
@@ -9,17 +9,17 @@ const migration: ConfigMigration = {
   id: "20260311120000_tasks_folder",
 
   async migrateAgent(_agentSlug, agentPath, context) {
-    const oldPath = join(agentPath, "workspace", "HEARTBEAT.md");
+    const oldPath = path.join(agentPath, "workspace", "HEARTBEAT.md");
     if (!existsSync(oldPath)) {
       return;
     }
 
     await context.backupFile(oldPath);
 
-    const tasksDir = join(agentPath, "tasks");
+    const tasksDir = path.join(agentPath, "tasks");
     await mkdir(tasksDir, { recursive: true });
 
-    const newPath = join(tasksDir, "HEARTBEAT.md");
+    const newPath = path.join(tasksDir, "HEARTBEAT.md");
     await rename(oldPath, newPath);
   },
 

--- a/packages/runtime/src/config/migrations/20260322000000_assistant_message_ids/migration.ts
+++ b/packages/runtime/src/config/migrations/20260322000000_assistant_message_ids/migration.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import path from "node:path";
 
 import { eq } from "drizzle-orm";
 import * as vb from "valibot";
@@ -16,7 +16,7 @@ const migration: ConfigMigration = {
   targets: [], // No TOML targets
 
   async migrateAgent(agentSlug, agentPath, context) {
-    const dbPath = join(agentPath, "sessions.db");
+    const dbPath = path.join(agentPath, "sessions.db");
     await context.backupFile(dbPath);
 
     const db = initDb(agentSlug);
@@ -33,7 +33,7 @@ const migration: ConfigMigration = {
           const content = Array.isArray(msg.content) ? msg.content : [msg.content];
           for (const block of content) {
             if (block.type === "text") {
-              const match = /<assistant-context msgId="([^"]+)"/.exec(block.content);
+              const match = /<assistant-context msgId="([^"]+)"/u.exec(block.content);
               if (match !== null) {
                 const [, msgId] = match;
                 if (msgId !== undefined) {
@@ -50,7 +50,7 @@ const migration: ConfigMigration = {
           const content = Array.isArray(msg.content) ? msg.content : [msg.content];
           for (const block of content) {
             if (block.type === "text") {
-              const match = /<(?:history-context|msg) msgId="([^"]+)"/.exec(block.content);
+              const match = /<(?:history-context|msg) msgId="([^"]+)"/u.exec(block.content);
               if (match !== null) {
                 const [, msgId] = match;
                 if (msgId !== undefined) {

--- a/packages/runtime/src/config/migrations/20260406000000_engine_providers/migration.ts
+++ b/packages/runtime/src/config/migrations/20260406000000_engine_providers/migration.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import type { TomlTable } from "smol-toml";
 import * as vb from "valibot";
@@ -105,7 +105,7 @@ export const migration: ConfigMigration = {
   async migrateAgent(agentSlug, agentPath, context) {
     const extra = extraProviders.get(agentSlug);
     if (extra !== undefined && Object.keys(extra).length > 0) {
-      const enginePath = join(agentPath, "config", "engine.toml");
+      const enginePath = path.join(agentPath, "config", "engine.toml");
       if (existsSync(enginePath)) {
         await context.backupFile(enginePath);
         const { parse, stringify } = await import("smol-toml");

--- a/packages/runtime/src/config/migrations/20260412000000_brave_search_plugin/migration.ts
+++ b/packages/runtime/src/config/migrations/20260412000000_brave_search_plugin/migration.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { parse, stringify } from "smol-toml";
 import type { TomlTable } from "smol-toml";
@@ -38,12 +38,12 @@ export const migration: ConfigMigration = {
 
     const { apiKey } = parsed.output.brave;
 
-    const pluginsDir = join(root(), "config", "plugins");
+    const pluginsDir = path.join(root(), "config", "plugins");
     if (!existsSync(pluginsDir)) {
       await mkdir(pluginsDir, { recursive: true });
     }
 
-    const pluginConfigPath = join(pluginsDir, "brave-search.toml");
+    const pluginConfigPath = path.join(pluginsDir, "brave-search.toml");
     if (!existsSync(pluginConfigPath)) {
       await context.backupFile(pluginConfigPath);
       const apiKeyToml =
@@ -53,7 +53,7 @@ export const migration: ConfigMigration = {
       await writeFile(pluginConfigPath, apiKeyToml, "utf8");
     }
 
-    const pluginsTomlPath = join(root(), "config", "plugins.toml");
+    const pluginsTomlPath = path.join(root(), "config", "plugins.toml");
     await context.backupFile(pluginsTomlPath);
 
     let pluginsToml: Record<string, unknown> = { plugins: [] };

--- a/packages/runtime/src/config/migrations/runner.ts
+++ b/packages/runtime/src/config/migrations/runner.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { join, basename } from "node:path";
+import path from "node:path";
 
 import { confirm, select } from "@inquirer/prompts";
 import { stringify } from "smol-toml";
@@ -12,8 +12,8 @@ import { info } from "#output/log.js";
 import { root } from "#util/paths.js";
 
 const MIGRATIONS_DIR = import.meta.dirname;
-const STATE_FILE = join(root(), "config", "migrations.json");
-const BACKUPS_DIR = join(root(), "config", "backups");
+const STATE_FILE = path.join(root(), "config", "migrations.json");
+const BACKUPS_DIR = path.join(root(), "config", "backups");
 
 const MigrationStateSchema = vb.object({
   applied: vb.array(vb.string()),
@@ -38,7 +38,7 @@ async function getMigrationState(): Promise<MigrationState> {
 }
 
 async function saveMigrationState(state: MigrationState): Promise<void> {
-  const dir = join(STATE_FILE, "..");
+  const dir = path.join(STATE_FILE, "..");
   if (!existsSync(dir)) {
     await mkdir(dir, { recursive: true });
   }
@@ -65,7 +65,7 @@ async function loadMigrations(): Promise<ConfigMigration[]> {
       continue;
     }
 
-    const migrationPath = join(MIGRATIONS_DIR, entry.name, "migration.ts");
+    const migrationPath = path.join(MIGRATIONS_DIR, entry.name, "migration.ts");
     if (!existsSync(migrationPath)) {
       continue;
     }
@@ -137,7 +137,7 @@ async function shouldApplyMigration(migration: ConfigMigration): Promise<boolean
 }
 
 function getBackupFilename(filePath: string): string {
-  const filename = basename(filePath);
+  const filename = path.basename(filePath);
 
   if (filePath.includes("/agents/")) {
     const parts = filePath.split("/agents/");
@@ -153,13 +153,13 @@ function getBackupFilename(filePath: string): string {
 }
 
 async function createBackup(migrationId: string, filePath: string, content: string): Promise<void> {
-  const backupDir = join(BACKUPS_DIR, migrationId);
+  const backupDir = path.join(BACKUPS_DIR, migrationId);
   if (!existsSync(backupDir)) {
     await mkdir(backupDir, { recursive: true });
   }
 
   const backupFilename = getBackupFilename(filePath);
-  const backupPath = join(backupDir, backupFilename);
+  const backupPath = path.join(backupDir, backupFilename);
   await writeFile(backupPath, content, { encoding: "utf8" });
 }
 
@@ -228,7 +228,7 @@ async function applyMigration(
   const globalConfigFiles = ["integrations.toml", "plugins.toml", "engine.toml"] as const;
   for (const filename of globalConfigFiles) {
     if (migration.targets.includes(filename)) {
-      const configPath = join(root(), "config", filename);
+      const configPath = path.join(root(), "config", filename);
       const context: MigrationContext = {
         backupFile: createBackupHelper(),
         configPath,
@@ -243,9 +243,9 @@ async function applyMigration(
       let configPath: string | undefined = undefined;
 
       if (target === "channels/discord.toml") {
-        configPath = join(root(), "agents", slug, "config", "channels", "discord.toml");
+        configPath = path.join(root(), "agents", slug, "config", "channels", "discord.toml");
       } else if (target !== "integrations.toml" && target !== "plugins.toml") {
-        configPath = join(root(), "agents", slug, "config", target);
+        configPath = path.join(root(), "agents", slug, "config", target);
       }
 
       if (configPath !== undefined) {
@@ -262,7 +262,7 @@ async function applyMigration(
 
   if (migration.migrateAgent !== undefined) {
     for (const slug of agentSlugs) {
-      const agentPath = join(root(), "agents", slug);
+      const agentPath = path.join(root(), "agents", slug);
       const context: MigrationContext = {
         agentSlug: slug,
         backupFile: createBackupHelper(),
@@ -288,7 +288,7 @@ export async function runMigrations(dryRun = false): Promise<number> {
     return 0;
   }
 
-  const agentsDir = join(root(), "agents");
+  const agentsDir = path.join(root(), "agents");
   let agentSlugs: string[] = [];
 
   if (existsSync(agentsDir)) {

--- a/packages/runtime/src/config/schemas/conditions.ts
+++ b/packages/runtime/src/config/schemas/conditions.ts
@@ -11,9 +11,9 @@ const ConditionStringSchema = vb.message(
       return (
         base === "discord:nsfw" ||
         base === "discord:dm" ||
-        /^discord:dm:\d+$/.test(base) ||
-        /^discord:guild:\d+$/.test(base) ||
-        /^discord:channel:\d+$/.test(base) ||
+        /^discord:dm:\d+$/u.test(base) ||
+        /^discord:guild:\d+$/u.test(base) ||
+        /^discord:channel:\d+$/u.test(base) ||
         base === "tui" ||
         base === "internal"
       );

--- a/packages/runtime/src/config/schemas/discord.ts
+++ b/packages/runtime/src/config/schemas/discord.ts
@@ -10,7 +10,7 @@ const DirectMessagesModeSchema = vb.pipe(
 const DirectMessagesSchema = vb.exactOptional(
   vb.strictObject({
     mode: DirectMessagesModeSchema,
-    users: vb.exactOptional(vb.array(vb.pipe(nonEmptyString, vb.regex(/[0-9]+/))), []),
+    users: vb.exactOptional(vb.array(vb.pipe(nonEmptyString, vb.regex(/[0-9]+/u))), []),
   }),
   {
     mode: "owner",
@@ -28,7 +28,7 @@ const AccessSchema = vb.exactOptional(
   vb.strictObject({
     mode: AccessModeSchema,
     users: vb.pipe(
-      vb.exactOptional(vb.array(vb.pipe(vb.string(), vb.regex(/[0-9]+/))), []),
+      vb.exactOptional(vb.array(vb.pipe(vb.string(), vb.regex(/[0-9]+/u))), []),
       vb.description("An array of discord user IDs"),
     ),
   }),
@@ -46,7 +46,7 @@ const DiscordConfigSchema = vb.strictObject({
   ownerId: vb.pipe(
     vb.string(),
     vb.nonEmpty(),
-    vb.regex(/[0-9]+/),
+    vb.regex(/[0-9]+/u),
     vb.description("The ID of the 'owner' of the agent."),
   ),
   timeout: vb.optional(

--- a/packages/runtime/src/config/schemas/sandbox.ts
+++ b/packages/runtime/src/config/schemas/sandbox.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from "node:path";
+import path from "node:path";
 
 import * as vb from "valibot";
 
@@ -8,7 +8,7 @@ const MountSchema = vb.object({
     vb.string(),
     vb.minLength(1),
     vb.check(
-      (it) => it.startsWith("~/") || isAbsolute(it),
+      (it) => it.startsWith("~/") || path.isAbsolute(it),
       "source must be an absolute path or start with ~/",
     ),
   ),

--- a/packages/runtime/src/db/index.ts
+++ b/packages/runtime/src/db/index.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import path from "node:path";
 
 import BetterSqlite3 from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -13,10 +13,10 @@ import * as schema from "./schema.js";
 type Database = Awaited<ReturnType<typeof drizzle<typeof schema>>>;
 
 // Map from agent slug to DB instance — each agent gets its own database.
-const _dbs = new Map<string, Database>();
+const databases = new Map<string, Database>();
 
 function getDb(agentSlug: string): Database {
-  const db = _dbs.get(agentSlug);
+  const db = databases.get(agentSlug);
   if (db === undefined) {
     throw new Error(`DB not initialized for agent '${agentSlug}' — call initDb(slug) first`);
   }
@@ -24,12 +24,12 @@ function getDb(agentSlug: string): Database {
 }
 
 function initDb(agentSlug: string): Database {
-  const existing = _dbs.get(agentSlug);
+  const existing = databases.get(agentSlug);
   if (existing !== undefined) {
     return existing;
   }
 
-  const dbPath = join(agentRoot(agentSlug), "sessions.db");
+  const dbPath = path.join(agentRoot(agentSlug), "sessions.db");
   const sqlite = new BetterSqlite3(dbPath);
 
   // WAL mode: better concurrent read performance and crash safety.
@@ -52,7 +52,7 @@ function initDb(agentSlug: string): Database {
     }
   }
 
-  _dbs.set(agentSlug, db);
+  databases.set(agentSlug, db);
   return db;
 }
 

--- a/packages/runtime/src/db/sessions.test.ts
+++ b/packages/runtime/src/db/sessions.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -23,11 +23,11 @@ afterEach(() => {
 });
 
 function initTestDb(): { slug: string } {
-  const home = mkdtempSync(join(tmpdir(), "cireilclaw-db-test-"));
+  const home = mkdtempSync(path.join(tmpdir(), "cireilclaw-db-test-"));
   vi.stubEnv("HOME", home);
 
   const slug = `agent-${randomUUID()}`;
-  mkdirSync(join(home, ".cireilclaw", "agents", slug), { recursive: true });
+  mkdirSync(path.join(home, ".cireilclaw", "agents", slug), { recursive: true });
   initDb(slug);
   return { slug };
 }

--- a/packages/runtime/src/db/sessions.ts
+++ b/packages/runtime/src/db/sessions.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
 
 import { blake3 } from "@noble/hashes/blake3.js";
 import { and, eq, inArray, notInArray } from "drizzle-orm";
@@ -30,12 +30,12 @@ const MEDIA_TYPE_EXT: Record<string, string> = {
 };
 
 function imageDir(agentSlug: string): string {
-  return join(agentRoot(agentSlug), "images");
+  return path.join(agentRoot(agentSlug), "images");
 }
 
 function imagePath(agentSlug: string, id: string, mediaType: string): string {
   const ext = MEDIA_TYPE_EXT[mediaType] ?? ".bin";
-  return join(imageDir(agentSlug), `${id}${ext}`);
+  return path.join(imageDir(agentSlug), `${id}${ext}`);
 }
 
 function hashImage(data: Uint8Array): string {
@@ -65,8 +65,8 @@ function serializeHistory(
     if (isImageContent(ct)) {
       const img = ct;
       const id = hashImage(img.data);
-      const path = imagePath(agentSlug, id, img.mediaType);
-      pendingImages.push({ data: img.data, id, mediaType: img.mediaType, path });
+      const pth = imagePath(agentSlug, id, img.mediaType);
+      pendingImages.push({ data: img.data, id, mediaType: img.mediaType, path: pth });
       return { id, mediaType: img.mediaType, type: "image_ref" } satisfies ImageRef;
     }
     // Videos are not stored on disk — just keep the URL and attachmentId as a ref.
@@ -95,14 +95,14 @@ function serializeHistory(
 
 async function deserializeHistory(json: string, agentSlug: string): Promise<Message[]> {
   function deserializeImageRef(ref: ImageRef): ImageContent | undefined {
-    const path = imagePath(agentSlug, ref.id, ref.mediaType);
+    const pth = imagePath(agentSlug, ref.id, ref.mediaType);
     try {
-      const data = readFileSync(path);
+      const data = readFileSync(pth);
       return { data, mediaType: ref.mediaType, type: "image" } satisfies ImageContent;
     } catch (error) {
       warning(
         "Failed to restore image for session:",
-        path,
+        pth,
         error instanceof Error ? error.message : String(error),
       );
       // Drop the image from the restored message rather than making the whole session unreadable.
@@ -235,18 +235,18 @@ const DEBOUNCE_MS = 2000;
 
 // Store the flush callback so flushAllSessions() can drain without needing
 // to re-fetch the session from somewhere.
-const _pending = new Map<string, { timer: NodeJS.Timeout; flush: () => void }>();
+const pending = new Map<string, { timer: NodeJS.Timeout; flush(this: void): void }>();
 
 // Flushes all pending debounced saves immediately — call before process exit
 // so in-flight data isn't lost.
 function flushAllSessions(): void {
-  for (const { timer, flush } of _pending.values()) {
+  for (const { timer, flush } of pending.values()) {
     clearTimeout(timer);
     flush();
   }
 }
 
-function _flushSession(agentSlug: string, session: Session): void {
+function flushSession(agentSlug: string, session: Session): void {
   // Ephemeral sessions are never persisted.
   if (session.ephemeral) {
     return;
@@ -289,8 +289,8 @@ function _flushSession(agentSlug: string, session: Session): void {
     session.lastActivity > 0 ? new Date(session.lastActivity).toISOString() : undefined;
 
   const activeFileSections: Record<string, string[]> = {};
-  for (const [path, sections] of session.activeFileSections) {
-    activeFileSections[path] = [...sections];
+  for (const [pth, sections] of session.activeFileSections) {
+    activeFileSections[pth] = [...sections];
   }
 
   // Upsert the session row first so that the images FK constraint is satisfied.
@@ -350,8 +350,8 @@ async function loadSessions(agentSlug: string): Promise<Map<string, Session>> {
     );
     const activeFileSections = new Map<string, Set<string>>();
     if (activeFileSectionsRaw.success) {
-      for (const [path, sections] of Object.entries(activeFileSectionsRaw.output)) {
-        activeFileSections.set(path, new Set(sections));
+      for (const [pth, sections] of Object.entries(activeFileSectionsRaw.output)) {
+        activeFileSections.set(pth, new Set(sections));
       }
     }
 
@@ -493,9 +493,9 @@ function deleteSession(agentSlug: string, sessionId: string): void {
       if (stillShared.has(img.id)) {
         continue;
       }
-      const path = imagePath(agentSlug, img.id, img.mediaType);
+      const pth = imagePath(agentSlug, img.id, img.mediaType);
       try {
-        unlinkSync(path);
+        unlinkSync(pth);
       } catch {
         // Already gone — fine.
       }
@@ -533,9 +533,9 @@ function resetSession(agentSlug: string, sessionId: string): void {
       if (stillShared.has(img.id)) {
         continue;
       }
-      const path = imagePath(agentSlug, img.id, img.mediaType);
+      const pth = imagePath(agentSlug, img.id, img.mediaType);
       try {
-        unlinkSync(path);
+        unlinkSync(pth);
       } catch {
         // Already gone.
       }
@@ -554,17 +554,17 @@ function resetSession(agentSlug: string, sessionId: string): void {
 // rapid back-to-back turns only produce one write.
 function saveSession(agentSlug: string, session: Session): void {
   const key = `${agentSlug}:${session.id()}`;
-  const existing = _pending.get(key);
+  const existing = pending.get(key);
   if (existing !== undefined) {
     clearTimeout(existing.timer);
   }
 
   function flush(): void {
-    _pending.delete(key);
-    _flushSession(agentSlug, session);
+    pending.delete(key);
+    flushSession(agentSlug, session);
   }
 
-  _pending.set(key, { flush, timer: setTimeout(flush, DEBOUNCE_MS) });
+  pending.set(key, { flush, timer: setTimeout(flush, DEBOUNCE_MS) });
 }
 
 function updateSessionImages(
@@ -640,8 +640,8 @@ function updateSessionImages(
       if (msg.role === "user" && msg.id !== undefined) {
         const data = newImages.get(msg.id);
         if (data !== undefined) {
-          const path = imagePath(agentSlug, block.id, block.mediaType);
-          pendingImages.push({ data, id: block.id, mediaType: block.mediaType, path });
+          const pth = imagePath(agentSlug, block.id, block.mediaType);
+          pendingImages.push({ data, id: block.id, mediaType: block.mediaType, path: pth });
         }
       }
     }
@@ -689,9 +689,9 @@ function updateSessionImages(
       continue;
     }
 
-    const path = imagePath(agentSlug, img.id, img.mediaType);
+    const pth = imagePath(agentSlug, img.id, img.mediaType);
     try {
-      unlinkSync(path);
+      unlinkSync(pth);
     } catch {
       // Already gone — fine.
     }

--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -425,8 +425,8 @@ export async function runTurn(
         }
 
         default: {
-          const _exhaustive: never = selectedProvider.kind;
-          throw new Error(`Unsupported provider type: ${String(_exhaustive)}`);
+          const exhaustive: never = selectedProvider.kind;
+          throw new Error(`Unsupported provider type: ${String(exhaustive)}`);
         }
       }
     } catch (error) {

--- a/packages/runtime/src/engine/outline.ts
+++ b/packages/runtime/src/engine/outline.ts
@@ -32,12 +32,12 @@ const DEFAULT_OUTLINE_THRESHOLD_TOKENS = 2000;
 // Built-in extractors
 // ---------------------------------------------------------------------------
 
-const HEADING_RE = /^(#{1,6})\s+(.+)$/gm;
-const SETEXT_H1_RE = /^(.+)\n=+\s*$/gm;
-const SETEXT_H2_RE = /^(.+)\n-+\s*$/gm;
+const HEADING_RE = /^(#{1,6})\s+(.+)$/gmu;
+const SETEXT_H1_RE = /^(.+)\n=+\s*$/gmu;
+const SETEXT_H2_RE = /^(.+)\n-+\s*$/gmu;
 
 function stripMarkdownLinks(text: string): string {
-  return text.replaceAll(/\[([^\]]+)\]\([^)]+\)/g, "$1").trim();
+  return text.replaceAll(/\[([^\]]+)\]\([^)]+\)/gu, "$1").trim();
 }
 
 function markdownExtractor(_filePath: string, content: string): Section[] {
@@ -53,8 +53,8 @@ function markdownExtractor(_filePath: string, content: string): Section[] {
     const lineNum = content.slice(0, match.index).split("\n").length;
     const id = text
       .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, "");
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, "");
 
     sections.push({
       id,
@@ -73,8 +73,8 @@ function markdownExtractor(_filePath: string, content: string): Section[] {
     sections.push({
       id: text
         .toLowerCase()
-        .replaceAll(/[^a-z0-9]+/g, "-")
-        .replaceAll(/^-+|-+$/g, ""),
+        .replaceAll(/[^a-z0-9]+/gu, "-")
+        .replaceAll(/^-+|-+$/gu, ""),
       label: text,
       line: lineNum,
       lines: 0,
@@ -89,8 +89,8 @@ function markdownExtractor(_filePath: string, content: string): Section[] {
     sections.push({
       id: text
         .toLowerCase()
-        .replaceAll(/[^a-z0-9]+/g, "-")
-        .replaceAll(/^-+|-+$/g, ""),
+        .replaceAll(/[^a-z0-9]+/gu, "-")
+        .replaceAll(/^-+|-+$/gu, ""),
       label: text,
       line: lineNum,
       lines: 0,
@@ -112,7 +112,7 @@ function markdownExtractor(_filePath: string, content: string): Section[] {
   return sections;
 }
 
-const XML_TAG_RE = /<(\w+)[^>]*?(?:\sid\s*=\s*"([^"]+)"|\sname\s*=\s*"([^"]+)")[^>]*>/g;
+const XML_TAG_RE = /<(\w+)[^>]*?(?:\sid\s*=\s*"([^"]+)"|\sname\s*=\s*"([^"]+)")[^>]*>/gu;
 
 function xmlExtractor(_filePath: string, content: string): Section[] {
   const sections: Section[] = [];

--- a/packages/runtime/src/engine/provider/model-metadata.ts
+++ b/packages/runtime/src/engine/provider/model-metadata.ts
@@ -134,8 +134,8 @@ async function fetchModelMetadataUncached(provider: ProviderConfig): Promise<Mod
     case "openai-codex":
       return OPENAI_CODEX_MODELS.map((id) => ({ id, name: id }));
     default: {
-      const _exhaustive: never = provider.kind;
-      throw new Error(`Unsupported provider type: ${String(_exhaustive)}`);
+      const exhaustive: never = provider.kind;
+      throw new Error(`Unsupported provider type: ${String(exhaustive)}`);
     }
   }
 }

--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -256,7 +256,7 @@ function translateMsg(message: Message): ChatCompletionMessageParam {
           msg["content"] = textBlocks.map((it) => ({ text: it.content, type: "text" }) as const);
         }
 
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertions
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
         return msg as unknown as ChatCompletionMessageParam;
       }
       if (message.content.type === "text") {
@@ -267,7 +267,7 @@ function translateMsg(message: Message): ChatCompletionMessageParam {
       }
       if (message.content.type === "thinking") {
         // Single thinking block, so send as reasoning_content with no text content.
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertions
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
         return {
           reasoning_content: message.content.thinking,
           role: "assistant",
@@ -373,10 +373,14 @@ export async function generate(
 
   if (reasoning === true) {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    (params as unknown as Record<string, unknown>)["reasoning"] = { enabled: true };
+    (params as unknown as Record<string, unknown>)["reasoning"] = {
+      enabled: true,
+    };
   } else if (typeof reasoning === "string") {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    (params as unknown as Record<string, unknown>)["reasoning"] = { effort: reasoning };
+    (params as unknown as Record<string, unknown>)["reasoning"] = {
+      effort: reasoning,
+    };
   }
 
   if (

--- a/packages/runtime/src/engine/provider/openai-codex-auth.ts
+++ b/packages/runtime/src/engine/provider/openai-codex-auth.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { Server } from "node:http";
-import { join } from "node:path";
+import path from "node:path";
 
 import * as vb from "valibot";
 
@@ -49,12 +49,12 @@ function validateAuthId(authId: string): void {
 }
 
 function codexAuthDir(): string {
-  return join(root(), "config", "openai-codex");
+  return path.join(root(), "config", "openai-codex");
 }
 
 function codexAuthPath(authId: string): string {
   validateAuthId(authId);
-  return join(codexAuthDir(), `${authId}.json`);
+  return path.join(codexAuthDir(), `${authId}.json`);
 }
 
 function base64Url(buffer: Buffer): string {
@@ -167,19 +167,19 @@ async function refreshAccessToken(refreshToken: string): Promise<CodexAuth> {
 }
 
 async function readCodexAuth(authId: string): Promise<CodexAuth | undefined> {
-  const path = codexAuthPath(authId);
-  if (!existsSync(path)) {
+  const authPath = codexAuthPath(authId);
+  if (!existsSync(authPath)) {
     return undefined;
   }
-  return vb.parse(CodexAuthSchema, JSON.parse(await readFile(path, { encoding: "utf8" })));
+  return vb.parse(CodexAuthSchema, JSON.parse(await readFile(authPath, { encoding: "utf8" })));
 }
 
 async function writeCodexAuth(authId: string, auth: CodexAuth): Promise<void> {
   const dir = codexAuthDir();
   await mkdir(dir, { mode: 0o700, recursive: true });
-  const path = codexAuthPath(authId);
-  await writeFile(path, JSON.stringify(auth, undefined, 2), { encoding: "utf8", mode: 0o600 });
-  await chmod(path, 0o600);
+  const authPath = codexAuthPath(authId);
+  await writeFile(authPath, JSON.stringify(auth, undefined, 2), { encoding: "utf8", mode: 0o600 });
+  await chmod(authPath, 0o600);
 }
 
 async function deleteCodexAuth(authId: string): Promise<void> {

--- a/packages/runtime/src/engine/provider/openai-codex.ts
+++ b/packages/runtime/src/engine/provider/openai-codex.ts
@@ -215,8 +215,8 @@ async function translateUserContent(
     case "video_ref":
       throw new Error("The OpenAI Codex provider does not support video input.");
     default: {
-      const _exhaustive: never = content;
-      throw new Error(`Unsupported user content: ${String(_exhaustive)}`);
+      const exhaustive: never = content;
+      throw new Error(`Unsupported user content: ${String(exhaustive)}`);
     }
   }
 }
@@ -307,8 +307,8 @@ async function translateMessagesForCodex(
         break;
       }
       default: {
-        const _exhaustive: never = message;
-        throw new Error(`Unsupported message role: ${String(_exhaustive)}`);
+        const exhaustive: never = message;
+        throw new Error(`Unsupported message role: ${String(exhaustive)}`);
       }
     }
   }

--- a/packages/runtime/src/engine/prune.topic.test.ts
+++ b/packages/runtime/src/engine/prune.topic.test.ts
@@ -7,17 +7,17 @@ function isTextContent(ct: unknown): ct is { content: string; type: "text" } {
   return typeof ct === "object" && ct !== null && "type" in ct && ct.type === "text";
 }
 
-describe("applyTopicSubstitution", () => {
-  function makeMsg(id: string, role: "user" | "assistant" | "toolResponse" = "user"): Message {
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    return {
-      content: { content: `message ${id}`, type: "text" },
-      id,
-      role,
-      timestamp: 1,
-    } as unknown as Message;
-  }
+function makeMsg(id: string, role: "user" | "assistant" | "toolResponse" = "user"): Message {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return {
+    content: { content: `message ${id}`, type: "text" },
+    id,
+    role,
+    timestamp: 1,
+  } as unknown as Message;
+}
 
+describe("applyTopicSubstitution", () => {
   test("returns messages unchanged when no summaries", () => {
     const messages = [makeMsg("a"), makeMsg("b"), makeMsg("c")];
     const result = applyTopicSubstitution(messages, []);

--- a/packages/runtime/src/engine/prune.ts
+++ b/packages/runtime/src/engine/prune.ts
@@ -74,8 +74,8 @@ function estimateContentTokens(block: Content): number {
     case "video_ref":
       return IMAGE_TOKEN_OVERHEAD;
     default: {
-      const _exhaustive: never = block;
-      return _exhaustive;
+      const exhaustive: never = block;
+      return exhaustive;
     }
   }
 }

--- a/packages/runtime/src/engine/summarizer.ts
+++ b/packages/runtime/src/engine/summarizer.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { parse } from "smol-toml";
 import * as vb from "valibot";
@@ -52,7 +52,7 @@ interface SummarizeResult {
 }
 
 async function loadSummarizationConfig(agentSlug: string): Promise<SummarizationConfig> {
-  const file = join(agentRoot(agentSlug), "config", "summarization.toml");
+  const file = path.join(agentRoot(agentSlug), "config", "summarization.toml");
   try {
     const content = await readFile(file, "utf8");
     const parsed = parse(content);
@@ -95,8 +95,8 @@ async function runSummarizer(
     preserve: [],
     slug: request.identifier
       .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, ""),
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, ""),
     startMessageId: "",
     summary: "",
   };

--- a/packages/runtime/src/engine/system-prompt.ts
+++ b/packages/runtime/src/engine/system-prompt.ts
@@ -17,7 +17,7 @@ const NO_CAPABILITIES: ChannelCapabilities = {
 function extractSectionContent(content: string, sectionId: string): string {
   const lines = content.split("\n");
 
-  const headingRegex = /^(#{1,6})\s+(.+)$/;
+  const headingRegex = /^(#{1,6})\s+(.+)$/u;
   let inSection = false;
   let currentLevel = 0;
   const result: string[] = [];
@@ -29,8 +29,8 @@ function extractSectionContent(content: string, sectionId: string): string {
       const text = headingMatch[2] ?? "";
       const id = text
         .toLowerCase()
-        .replaceAll(/[^a-z0-9]+/g, "-")
-        .replaceAll(/^-+|-+$/g, "");
+        .replaceAll(/[^a-z0-9]+/gu, "-")
+        .replaceAll(/^-+|-+$/gu, "");
 
       if (id === sectionId) {
         inSection = true;
@@ -59,8 +59,8 @@ function extractSectionContent(content: string, sectionId: string): string {
   }
 
   const xmlRegex = new RegExp(
-    `<\\w+[^>]*?(?:\\sid\\s*=\\s*"${sectionId.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}"|\\sname\\s*=\\s*"${sectionId.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}")[^>]*>`,
-    "i",
+    `<\\w+[^>]*?(?:\\sid\\s*=\\s*"${sectionId.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)}"|\\sname\\s*=\\s*"${sectionId.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)}")[^>]*>`,
+    "iu",
   );
   const xmlMatch = xmlRegex.exec(content);
   if (xmlMatch !== null) {

--- a/packages/runtime/src/engine/tools/download-attachments.ts
+++ b/packages/runtime/src/engine/tools/download-attachments.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import path from "node:path";
 
 import * as vb from "valibot";
 
@@ -35,7 +35,7 @@ const downloadAttachments: ToolDef = {
 
     const saved: string[] = [];
     for (const { filename, data } of files) {
-      const sandboxPath = join(to, `${message_id}-${filename}`).replaceAll("\\", "/");
+      const sandboxPath = path.join(to, `${message_id}-${filename}`).replaceAll("\\", "/");
 
       await ctx.paths.checkConditionalAccess(sandboxPath);
 
@@ -48,7 +48,7 @@ const downloadAttachments: ToolDef = {
         );
       }
 
-      await mkdir(dirname(realPath), { recursive: true });
+      await mkdir(path.dirname(realPath), { recursive: true });
       await writeFile(realPath, data);
       saved.push(sandboxPath);
     }

--- a/packages/runtime/src/engine/tools/exec.ts
+++ b/packages/runtime/src/engine/tools/exec.ts
@@ -2,9 +2,8 @@ import * as vb from "valibot";
 
 import { ToolError } from "#engine/errors.js";
 import type { ToolContext, ToolDef } from "#engine/tools/tool-def.js";
-import { exec as sandboxExec } from "#util/sandbox.js";
+import { exec as sandboxExec, SHELL_METACHAR_PATTERN } from "#util/sandbox.js";
 
-const SHELL_METACHAR_PATTERN = /[\s"'|&;$`\\]/;
 const Schema = vb.strictObject({
   args: vb.pipe(
     vb.optional(vb.nullable(vb.array(vb.pipe(vb.string(), vb.nonEmpty())))),

--- a/packages/runtime/src/engine/tools/list-sessions.ts
+++ b/packages/runtime/src/engine/tools/list-sessions.ts
@@ -115,7 +115,7 @@ export const listSessions: ToolDef = {
             }
           }
         } else {
-          let text = textContent.content.replaceAll(/<[^>]*>/g, "").trim();
+          let text = textContent.content.replaceAll(/<[^>]*>/gu, "").trim();
           if (text === "") {
             // If stripping tags left nothing, maybe it's just tags or metadata.
             // Use the original content as fallback.

--- a/packages/runtime/src/engine/tools/list-sessions.ts
+++ b/packages/runtime/src/engine/tools/list-sessions.ts
@@ -115,6 +115,7 @@ export const listSessions: ToolDef = {
             }
           }
         } else {
+          // Not used for HTML; this is fine to leave as-is.
           let text = textContent.content.replaceAll(/<[^>]*>/gu, "").trim();
           if (text === "") {
             // If stripping tags left nothing, maybe it's just tags or metadata.

--- a/packages/runtime/src/engine/tools/prune-boundaries.ts
+++ b/packages/runtime/src/engine/tools/prune-boundaries.ts
@@ -79,8 +79,8 @@ export const pruneBoundaries: ToolDef = {
 
     const slug = data.identifier
       .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replaceAll(/^-+|-+$/g, "");
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, "");
 
     if (slug.length === 0) {
       throw new ToolError(

--- a/packages/runtime/src/engine/tools/query-sessions.ts
+++ b/packages/runtime/src/engine/tools/query-sessions.ts
@@ -47,13 +47,13 @@ function getMatchFn(query: string, mode: "raw" | "glob" | "regex"): (text: strin
     case "raw":
       return (text) => text.includes(query);
     case "glob": {
-      const escaped = query.replaceAll(/[.+^${}()|[\]\\]/g, String.raw`\$&`);
+      const escaped = query.replaceAll(/[.+^${}()|[\]\\]/gu, String.raw`\$&`);
       const regexStr = escaped.replaceAll(String.raw`\*`, ".*").replaceAll(String.raw`\?`, ".");
-      const regex = new RegExp(`^${regexStr}$`, "i");
+      const regex = new RegExp(`^${regexStr}$`, "iu");
       return (text) => regex.test(text);
     }
     case "regex": {
-      const regex = new RegExp(query, "i");
+      const regex = new RegExp(query, "iu");
       return (text) => regex.test(text);
     }
     default:

--- a/packages/runtime/src/engine/tools/read.ts
+++ b/packages/runtime/src/engine/tools/read.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from "node:fs/promises";
-import { extname } from "node:path";
+import path from "node:path";
 
 import * as vb from "valibot";
 
@@ -40,7 +40,7 @@ export const read: ToolDef = {
 
     const { size } = await stat(realPath);
 
-    const mediaType = IMAGE_EXT_TO_MEDIA_TYPE[extname(data.path).toLowerCase()];
+    const mediaType = IMAGE_EXT_TO_MEDIA_TYPE[path.extname(data.path).toLowerCase()];
     if (mediaType !== undefined) {
       const buf = await readFile(realPath);
       const webp = await toWebp(

--- a/packages/runtime/src/engine/tools/schedule.ts
+++ b/packages/runtime/src/engine/tools/schedule.ts
@@ -22,7 +22,7 @@ const Schema = vb.strictObject({
   id: vb.pipe(
     vb.string(),
     vb.nonEmpty(),
-    vb.regex(/^[a-z0-9-]+$/, "ID must be lowercase alphanumeric with hyphens"),
+    vb.regex(/^[a-z0-9-]+$/u, "ID must be lowercase alphanumeric with hyphens"),
     vb.description(
       "Unique slug-format identifier for this job (e.g. meeting-reminder). Lowercase alphanumeric with hyphens.",
     ),

--- a/packages/runtime/src/engine/tools/tool-def.ts
+++ b/packages/runtime/src/engine/tools/tool-def.ts
@@ -17,15 +17,24 @@ interface InternalToolContext extends PluginToolContext {
     sandbox: SandboxConfig;
   };
   reply: PluginToolContext["reply"] & {
-    sendTo: (targetSession: Session, content: string, attachments?: string[]) => Promise<void>;
+    sendTo(
+      this: void,
+      targetSession: Session,
+      content: string,
+      attachments?: string[],
+    ): Promise<void>;
   };
   channel: PluginToolContext["channel"] & {
-    downloadAttachments?: (messageId: string) => Promise<{ filename: string; data: Buffer }[]>;
-    fetchHistory?: (
+    downloadAttachments?(
+      this: void,
+      messageId: string,
+    ): Promise<{ filename: string; data: Buffer }[]>;
+    fetchHistory?(
+      this: void,
       messageId: string,
       direction: HistoryDirection,
       limit?: number,
-    ) => Promise<HistoryMessage[]>;
+    ): Promise<HistoryMessage[]>;
   };
   scheduler?: Scheduler;
 }

--- a/packages/runtime/src/engine/tools/write.ts
+++ b/packages/runtime/src/engine/tools/write.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import path from "node:path";
 
 import * as vb from "valibot";
 
@@ -49,7 +49,7 @@ export const write: ToolDef = {
     await ctx.paths.checkConditionalAccess(data.path);
     await ctx.paths.checkWriteAccess(data.path);
 
-    await mkdir(dirname(realPath), { recursive: true });
+    await mkdir(path.dirname(realPath), { recursive: true });
     await writeFile(realPath, data.content, "utf8");
 
     // Invalidate section cache — file content changed

--- a/packages/runtime/src/harness/index.ts
+++ b/packages/runtime/src/harness/index.ts
@@ -1,32 +1,28 @@
 import type { Agent } from "#agent/index.js";
 
 export class Harness {
-  private static _instance: Harness | undefined;
+  private static instance: Harness | undefined;
 
-  private readonly _agents: Map<string, Agent>;
+  public readonly agents: Map<string, Agent>;
 
   private constructor(agents: Map<string, Agent>) {
-    this._agents = agents;
+    this.agents = agents;
   }
 
   public static init(agents: Map<string, Agent>): Harness {
-    Harness._instance = new Harness(agents);
-    return Harness._instance;
+    Harness.instance = new Harness(agents);
+    return Harness.instance;
   }
 
   public static get(): Harness {
-    if (Harness._instance === undefined) {
+    if (Harness.instance === undefined) {
       throw new Error("Harness.get() called before Harness.init()");
     }
-    return Harness._instance;
-  }
-
-  public get agents(): Map<string, Agent> {
-    return this._agents;
+    return Harness.instance;
   }
 
   public async startSchedulers(): Promise<void> {
-    for (const agent of this._agents.values()) {
+    for (const agent of this.agents.values()) {
       await agent.scheduler?.start();
     }
   }

--- a/packages/runtime/src/output/colors.ts
+++ b/packages/runtime/src/output/colors.ts
@@ -1,6 +1,4 @@
-import { Chalk } from "chalk";
-
-const chalk = new Chalk();
+import chalk from "chalk";
 
 const number = chalk.green;
 const path = chalk.blue;

--- a/packages/runtime/src/output/log.ts
+++ b/packages/runtime/src/output/log.ts
@@ -7,7 +7,7 @@ import {
   renameSync,
   statSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import path from "node:path";
 
 import color from "#output/colors.js";
 
@@ -22,9 +22,9 @@ const config: LogConfig = { level: "debug" };
 const MAX_BYTES = 10 * 1024 * 1024;
 const MAX_BACKUPS = 5;
 
-let _fd: number | undefined = undefined;
-let _filePath: string | undefined = undefined;
-let _bytesWritten = 0;
+let fd: number | undefined = undefined;
+let filePath: string | undefined = undefined;
+let bytesWritten = 0;
 
 // oxlint-disable-next-line no-control-regex
 const ANSI_RE = /\u001B\[[0-9;]*m/gu;
@@ -54,35 +54,35 @@ function serializeArgs(level: Level, data: unknown[]): Record<string, unknown> {
   return { level, msg, ts: new Date().toISOString(), ...extra };
 }
 
-function rotate(filePath: string): void {
+function rotate(filePth: string): void {
   for (let idx = MAX_BACKUPS - 1; idx >= 1; idx--) {
-    const from = `${filePath}.${idx}`;
-    const to = `${filePath}.${idx + 1}`;
+    const from = `${filePth}.${idx}`;
+    const to = `${filePth}.${idx + 1}`;
     if (existsSync(from)) {
       renameSync(from, to);
     }
   }
-  if (_fd !== undefined) {
-    closeSync(_fd);
-    _fd = undefined;
+  if (fd !== undefined) {
+    closeSync(fd);
+    fd = undefined;
   }
-  if (existsSync(filePath)) {
-    renameSync(filePath, `${filePath}.1`);
+  if (existsSync(filePth)) {
+    renameSync(filePth, `${filePth}.1`);
   }
-  _fd = openSync(filePath, "a");
-  _bytesWritten = 0;
+  fd = openSync(filePth, "a");
+  bytesWritten = 0;
 }
 
 function writeToFile(level: Level, data: unknown[]): void {
-  if (_fd === undefined || _filePath === undefined) {
+  if (fd === undefined || filePath === undefined) {
     return;
   }
   try {
     const line = `${JSON.stringify(serializeArgs(level, data))}\n`;
-    appendFileSync(_fd, line);
-    _bytesWritten += Buffer.byteLength(line);
-    if (_bytesWritten >= MAX_BYTES) {
-      rotate(_filePath);
+    appendFileSync(fd, line);
+    bytesWritten += Buffer.byteLength(line);
+    if (bytesWritten >= MAX_BYTES) {
+      rotate(filePath);
     }
   } catch {
     // Never let a log write failure crash the application.
@@ -95,15 +95,15 @@ function isEnabled(callLevel: Level): boolean {
   return LEVEL_RANK[callLevel] >= LEVEL_RANK[config.level];
 }
 
-function setLogFile(filePath: string): void {
-  mkdirSync(dirname(filePath), { recursive: true });
-  _filePath = filePath;
-  _fd = openSync(filePath, "a");
+function setLogFile(filePth: string): void {
+  mkdirSync(path.dirname(filePth), { recursive: true });
+  filePath = filePth;
+  fd = openSync(filePth, "a");
   // Seed _bytesWritten from any pre-existing file size so rotation triggers correctly.
   try {
-    _bytesWritten = statSync(filePath).size;
+    bytesWritten = statSync(filePth).size;
   } catch {
-    _bytesWritten = 0;
+    bytesWritten = 0;
   }
 }
 

--- a/packages/runtime/src/output/log.ts
+++ b/packages/runtime/src/output/log.ts
@@ -97,6 +97,14 @@ function isEnabled(callLevel: Level): boolean {
 
 function setLogFile(filePth: string): void {
   mkdirSync(path.dirname(filePth), { recursive: true });
+  if (fd !== undefined) {
+    try {
+      closeSync(fd);
+    } catch {
+      // Ignore close errors on rotation/reconfiguration.
+    }
+    fd = undefined;
+  }
   filePath = filePth;
   fd = openSync(filePth, "a");
   // Seed _bytesWritten from any pre-existing file size so rotation triggers correctly.

--- a/packages/runtime/src/output/log.ts
+++ b/packages/runtime/src/output/log.ts
@@ -107,7 +107,7 @@ function setLogFile(filePth: string): void {
   }
   filePath = filePth;
   fd = openSync(filePth, "a");
-  // Seed _bytesWritten from any pre-existing file size so rotation triggers correctly.
+  // Seed bytesWritten from any pre-existing file size so rotation triggers correctly.
   try {
     bytesWritten = statSync(filePth).size;
   } catch {

--- a/packages/runtime/src/plugin/loader.ts
+++ b/packages/runtime/src/plugin/loader.ts
@@ -4,7 +4,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 
@@ -45,7 +45,7 @@ function readSdkVersion(pkgPath: string): string {
 const RUNTIME_SDK_VERSION = readSdkVersion(RUNTIME_SDK_PKG);
 
 async function loadPluginsConfig(): Promise<vb.InferOutput<typeof PluginsConfigSchema>> {
-  const file = join(root(), "config", "plugins.toml");
+  const file = path.join(root(), "config", "plugins.toml");
   if (!existsSync(file)) {
     return { plugins: [] };
   }
@@ -55,7 +55,7 @@ async function loadPluginsConfig(): Promise<vb.InferOutput<typeof PluginsConfigS
 }
 
 async function ensureLocalPackageJson(): Promise<string> {
-  const pkgPath = join(root(), "package.json");
+  const pkgPath = path.join(root(), "package.json");
   if (!existsSync(pkgPath)) {
     const skeleton = {
       dependencies: {},
@@ -99,15 +99,15 @@ async function resolveEntryUrl(
   entry: PluginEntry,
 ): Promise<{ id: string; pluginPkgPath: string; url: URL }> {
   if (entry.name !== undefined) {
-    const dir = join(root(), "plugins", entry.name);
-    const pkgPath = join(dir, "package.json");
+    const dir = path.join(root(), "plugins", entry.name);
+    const pkgPath = path.join(dir, "package.json");
     if (!existsSync(pkgPath)) {
       throw new Error(
         `Plugin ${colors.keyword(entry.name)} not found at ${colors.keyword(dir)}. ` +
           `Clone it there: git clone <url> ${dir}`,
       );
     }
-    if (!existsSync(join(dir, "node_modules"))) {
+    if (!existsSync(path.join(dir, "node_modules"))) {
       throw new Error(
         `Plugin ${colors.keyword(entry.name)} is missing dependencies. ` +
           `Run: cd ${dir} && pnpm install`,

--- a/packages/runtime/src/plugin/rpc.test.ts
+++ b/packages/runtime/src/plugin/rpc.test.ts
@@ -71,7 +71,7 @@ describe("RpcChannel", () => {
   it("times out a pending call when timeoutMs elapses", async () => {
     const [client, server] = pair();
     server.handle("hang", async () => await hangForever());
-    await expect(client.call("hang", [], 50)).rejects.toThrow(/timed out after 50ms/);
+    await expect(client.call("hang", [], 50)).rejects.toThrow(/timed out after 50ms/u);
   });
 
   it("clears timer when response arrives before timeout", async () => {

--- a/packages/runtime/src/plugin/rpc.ts
+++ b/packages/runtime/src/plugin/rpc.ts
@@ -4,9 +4,9 @@
 import type { MessagePort, Worker } from "node:worker_threads";
 
 interface PortLike {
-  postMessage: (message: unknown) => void;
-  on: (event: "message", handler: (message: unknown) => void) => unknown;
-  off: (event: "message", handler: (message: unknown) => void) => unknown;
+  postMessage(message: unknown): void;
+  on(event: "message", handler: (message: unknown) => void): unknown;
+  off(event: "message", handler: (message: unknown) => void): unknown;
 }
 
 interface RpcRequest {
@@ -64,8 +64,8 @@ class RpcChannel {
   private readonly pending = new Map<
     number,
     {
-      resolve: (value: unknown) => void;
-      reject: (error: Error) => void;
+      resolve(this: void, value: unknown): void;
+      reject(this: void, error: Error): void;
       timer?: NodeJS.Timeout;
     }
   >();
@@ -91,8 +91,8 @@ class RpcChannel {
     const id = this.nextId++;
     return await new Promise<T>((resolve, reject) => {
       const entry: {
-        resolve: (value: unknown) => void;
-        reject: (error: Error) => void;
+        resolve(value: unknown): void;
+        reject(error: Error): void;
         timer?: NodeJS.Timeout;
       } = {
         reject,
@@ -200,9 +200,9 @@ class RpcChannel {
 // Structural compatibility checks — fail at type-check time if Node's Worker/MessagePort drift.
 type _WorkerCompat = Worker extends PortLike ? true : false;
 type _MessagePortCompat = MessagePort extends PortLike ? true : false;
-const _compatCheck: [_WorkerCompat, _MessagePortCompat] = [true, true];
+const compatCheck: [_WorkerCompat, _MessagePortCompat] = [true, true];
 // oxlint-disable-next-line eslint/no-void -- sink unused type-level marker
-void _compatCheck;
+void compatCheck;
 
 export type { PortLike };
 export { RpcChannel };

--- a/packages/runtime/src/scheduler/heartbeat.ts
+++ b/packages/runtime/src/scheduler/heartbeat.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import type { Agent } from "#agent/index.js";
 import type { HeartbeatConfig } from "#config/heartbeat.js";
@@ -79,7 +79,7 @@ async function runHeartbeat(agent: Agent, cfg: HeartbeatConfig): Promise<void> {
     return;
   }
 
-  const checklistPath = join(agentRoot(agent.slug), "tasks", "HEARTBEAT.md");
+  const checklistPath = path.join(agentRoot(agent.slug), "tasks", "HEARTBEAT.md");
   if (!existsSync(checklistPath)) {
     debug("Heartbeat: no HEARTBEAT.md found — skipping");
     return;

--- a/packages/runtime/src/scheduler/index.ts
+++ b/packages/runtime/src/scheduler/index.ts
@@ -24,35 +24,35 @@ function fromTimeout(timer: NodeJS.Timeout): StopHandle {
 }
 
 export class Scheduler {
-  private readonly _agent: Agent;
-  private readonly _signal: AbortSignal;
-  private _heartbeatHandle: StopHandle | undefined = undefined;
-  private readonly _cronHandles = new Map<string, StopHandle>();
+  private readonly agent: Agent;
+  private readonly signal: AbortSignal;
+  private heartbeatHandle: StopHandle | undefined = undefined;
+  private readonly cronHandles = new Map<string, StopHandle>();
 
   public constructor(agent: Agent, signal: AbortSignal) {
-    this._agent = agent;
-    this._signal = signal;
+    this.agent = agent;
+    this.signal = signal;
   }
 
   public async start(): Promise<void> {
-    if (this._signal.aborted) {
+    if (this.signal.aborted) {
       return;
     }
 
     const [heartbeatCfg, cronCfg] = await Promise.all([
-      loadHeartbeat(this._agent.slug),
-      loadCron(this._agent.slug),
+      loadHeartbeat(this.agent.slug),
+      loadCron(this.agent.slug),
     ]);
 
-    this._scheduleHeartbeat(heartbeatCfg);
+    this.scheduleHeartbeat(heartbeatCfg);
 
     for (const job of cronCfg.jobs) {
       if (job.enabled) {
-        this._scheduleCronJob(job);
+        this.scheduleCronJob(job);
       }
     }
 
-    for (const row of getAgentCronJobs(this._agent.slug)) {
+    for (const row of getAgentCronJobs(this.agent.slug)) {
       if (row.type !== "one-shot" || row.status !== "pending") {
         continue;
       }
@@ -61,7 +61,7 @@ export class Scheduler {
       }
       try {
         const cfg = vb.parse(CronJobConfigSchema, JSON.parse(row.config));
-        this._scheduleCronJob(cfg);
+        this.scheduleCronJob(cfg);
       } catch (error) {
         warning(
           "Scheduler: failed to parse persisted cron job",
@@ -73,34 +73,33 @@ export class Scheduler {
   }
 
   public stop(): void {
-    this._heartbeatHandle?.stop();
-    this._heartbeatHandle = undefined;
+    this.heartbeatHandle?.stop();
+    this.heartbeatHandle = undefined;
 
-    for (const [id, handle] of this._cronHandles) {
+    for (const [id, handle] of this.cronHandles) {
       handle.stop();
       debug("Scheduler: stopped cron job", colors.keyword(id));
     }
-    this._cronHandles.clear();
+    this.cronHandles.clear();
   }
 
   public async reload(): Promise<void> {
     this.stop();
     await this.start();
-    debug("Scheduler: reloaded for agent", colors.keyword(this._agent.slug));
+    debug("Scheduler: reloaded for agent", colors.keyword(this.agent.slug));
   }
 
   public scheduleDynamic(job: CronJobConfig): void {
-    this._scheduleCronJob(job);
+    this.scheduleCronJob(job);
   }
 
-  private _scheduleHeartbeat(cfg: HeartbeatConfig): void {
-    if (!cfg.enabled || this._signal.aborted) {
+  private scheduleHeartbeat(cfg: HeartbeatConfig): void {
+    if (!cfg.enabled || this.signal.aborted) {
       return;
     }
 
     const intervalMs = cfg.interval * 1000;
-    const agent = this._agent;
-    const signal = this._signal;
+    const { agent, signal } = this;
     // oxlint-disable-next-line no-this-alias no-this-assignment
     const parent = this;
 
@@ -124,13 +123,13 @@ export class Scheduler {
 
         if (!signal.aborted) {
           const timer = setTimeout(fire, intervalMs);
-          parent._heartbeatHandle = fromTimeout(timer);
+          parent.heartbeatHandle = fromTimeout(timer);
         }
       })();
     }
 
     const timer = setTimeout(fire, intervalMs);
-    this._heartbeatHandle = fromTimeout(timer);
+    this.heartbeatHandle = fromTimeout(timer);
     debug(
       "Scheduler: heartbeat scheduled for agent",
       colors.keyword(agent.slug),
@@ -138,15 +137,15 @@ export class Scheduler {
     );
   }
 
-  private _scheduleCronJob(job: CronJobConfig): void {
-    if (this._signal.aborted) {
+  private scheduleCronJob(job: CronJobConfig): void {
+    if (this.signal.aborted) {
       return;
     }
 
     const { schedule } = job;
 
     if ("cron" in schedule) {
-      this._scheduleCronExpression(job, schedule.cron);
+      this.scheduleCronExpression(job, schedule.cron);
       return;
     }
 
@@ -165,8 +164,7 @@ export class Scheduler {
       }
     }
 
-    const agent = this._agent;
-    const signal = this._signal;
+    const { agent, signal } = this;
 
     const fire = (): void => {
       if (signal.aborted) {
@@ -191,24 +189,23 @@ export class Scheduler {
       // oxlint-disable-next-line typescript/no-unnecessary-condition
       if (recurring && !signal.aborted) {
         const timer = setTimeout(fire, delayMs);
-        this._cronHandles.set(job.id, fromTimeout(timer));
+        this.cronHandles.set(job.id, fromTimeout(timer));
       } else {
-        this._cronHandles.delete(job.id);
+        this.cronHandles.delete(job.id);
       }
     };
 
     const timer = setTimeout(fire, delayMs);
-    this._cronHandles.set(job.id, fromTimeout(timer));
+    this.cronHandles.set(job.id, fromTimeout(timer));
     debug("Scheduler: cron job", colors.keyword(job.id), "scheduled in", `${delayMs}ms`);
   }
 
-  private _scheduleCronExpression(job: CronJobConfig, expression: string): void {
-    if (this._signal.aborted) {
+  private scheduleCronExpression(job: CronJobConfig, expression: string): void {
+    if (this.signal.aborted) {
       return;
     }
 
-    const agent = this._agent;
-    const signal = this._signal;
+    const { agent, signal } = this;
 
     const cronJob = new Cron(expression, async () => {
       if (signal.aborted) {
@@ -226,7 +223,7 @@ export class Scheduler {
       }
     });
 
-    this._cronHandles.set(job.id, cronJob);
+    this.cronHandles.set(job.id, cronJob);
     debug("Scheduler: cron expression job", colors.keyword(job.id), "scheduled:", expression);
   }
 }

--- a/packages/runtime/src/util/image.ts
+++ b/packages/runtime/src/util/image.ts
@@ -35,8 +35,7 @@ async function toWebp(data: ArrayBuffer, mediaType?: string): Promise<Uint8Array
       // implementation calls `.slice()` and spreads the result, which only
       // works on typed arrays. Wrapping in Uint8Array fixes the runtime error;
       // the cast silences the type mismatch.
-      // oxlint-disable-next-line no-unsafe-type-assertion
-      buffer: new Uint8Array(data) as unknown as ArrayBufferLike,
+      buffer: new Uint8Array(data),
     });
     const result = await sharp(Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength), {
       raw: { channels: 4, height, width },

--- a/packages/runtime/src/util/load.ts
+++ b/packages/runtime/src/util/load.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
-import { format, join } from "node:path";
+import path from "node:path";
 
 import { parse } from "smol-toml";
 import * as vb from "valibot";
@@ -22,7 +22,7 @@ type Frontmatter = Omit<MemoryBlock, "content" | "label" | "metadata" | "filePat
 function parseBlockFrontmatter(
   content: string,
   displayName: string,
-  path: string,
+  filePath: string,
   subject = "Base file",
 ): {
   body: string;
@@ -30,14 +30,14 @@ function parseBlockFrontmatter(
 } {
   if (content.indexOf("+++", 0) !== 0) {
     throw new Error(
-      `${subject} ${colors.keyword(displayName)} at path ${colors.path(path)} has an invalid frontmatter (expected TOML, but file does not start with '${colors.keyword("+++")}')`,
+      `${subject} ${colors.keyword(displayName)} at path ${colors.path(filePath)} has an invalid frontmatter (expected TOML, but file does not start with '${colors.keyword("+++")}')`,
     );
   }
 
   const ending = content.indexOf("+++", 3);
   if (ending === -1) {
     throw new Error(
-      `${subject} ${colors.keyword(displayName)} at path ${colors.path(path)} has an invalid frontmatter (expected closing '${colors.keyword("+++")}', but none found)`,
+      `${subject} ${colors.keyword(displayName)} at path ${colors.path(filePath)} has an invalid frontmatter (expected closing '${colors.keyword("+++")}', but none found)`,
     );
   }
 
@@ -59,12 +59,12 @@ const labels = ["soul", "identity", "person", "long-term", "style-notes"] as con
 type BlockLabel = (typeof labels)[number];
 
 async function loadBlocks(slug: string): Promise<Record<BlockLabel, MemoryBlock>> {
-  const rootPath = join(root(), "agents", slug, "blocks");
+  const rootPath = path.join(root(), "agents", slug, "blocks");
 
   const files = new Map<BlockLabel, MemoryBlock>();
 
   for (const label of labels) {
-    const it = format({
+    const it = path.format({
       dir: rootPath,
       ext: ".md",
       name: label,
@@ -95,9 +95,9 @@ async function loadBlocks(slug: string): Promise<Record<BlockLabel, MemoryBlock>
 }
 
 async function loadBaseInstructions(slug: string): Promise<string> {
-  const rootPath = join(root(), "agents", slug);
+  const rootPath = path.join(root(), "agents", slug);
 
-  const it = format({
+  const it = path.format({
     dir: rootPath,
     ext: ".md",
     name: "core",
@@ -125,7 +125,7 @@ const FrontmatterSchema = vb.object({
 });
 
 async function loadSkills(agentSlug: string): Promise<Skill[]> {
-  const skillsPath = join(root(), "agents", agentSlug, "skills");
+  const skillsPath = path.join(root(), "agents", agentSlug, "skills");
 
   if (!existsSync(skillsPath)) {
     return [];
@@ -140,7 +140,7 @@ async function loadSkills(agentSlug: string): Promise<Skill[]> {
     }
 
     const slug = entry.name;
-    const filePath = join(skillsPath, slug, "SKILL.md");
+    const filePath = path.join(skillsPath, slug, "SKILL.md");
 
     if (!existsSync(filePath)) {
       continue;
@@ -183,7 +183,7 @@ async function loadConditionalBlocks(
     return [];
   }
 
-  const conditionalPath = join(root(), "agents", agentSlug, "blocks", "conditional");
+  const conditionalPath = path.join(root(), "agents", agentSlug, "blocks", "conditional");
   if (!existsSync(conditionalPath)) {
     return [];
   }
@@ -191,7 +191,7 @@ async function loadConditionalBlocks(
   const blocks: MemoryBlock[] = [];
 
   for (const name of matchingNames) {
-    const filePath = join(conditionalPath, `${name}.md`);
+    const filePath = path.join(conditionalPath, `${name}.md`);
 
     if (!existsSync(filePath)) {
       continue;

--- a/packages/runtime/src/util/paths.test.ts
+++ b/packages/runtime/src/util/paths.test.ts
@@ -297,19 +297,19 @@ describe("validateSystemPath", () => {
   });
 });
 
-describe("checkConditionalAccess", () => {
-  function makeSession(opts: {
-    channelId: string;
-    guildId?: string;
-    isNsfw?: boolean;
-  }): DiscordSession {
-    return new DiscordSession({
-      channelId: opts.channelId,
-      guildId: opts.guildId,
-      isNsfw: opts.isNsfw ?? false,
-    });
-  }
+function makeSession(opts: {
+  channelId: string;
+  guildId?: string;
+  isNsfw?: boolean;
+}): DiscordSession {
+  return new DiscordSession({
+    channelId: opts.channelId,
+    guildId: opts.guildId,
+    isNsfw: opts.isNsfw ?? false,
+  });
+}
 
+describe("checkConditionalAccess", () => {
   it("allows /blocks paths unconditionally (no rules)", () => {
     const session = makeSession({ channelId: "123" });
     const conditions: ConditionsConfig = { blocks: {}, memories: {}, workspace: {} };

--- a/packages/runtime/src/util/paths.ts
+++ b/packages/runtime/src/util/paths.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, normalize, relative } from "node:path";
+import path from "node:path";
 import { env } from "node:process";
 
 import type { ConditionsConfig, PathRule } from "#config/schemas/conditions.js";
@@ -14,16 +14,16 @@ function root(): string {
     throw new Error("$HOME variable not available");
   }
 
-  if (!isAbsolute(home)) {
+  if (!path.isAbsolute(home)) {
     throw new Error("$HOME is not an absolute path");
   }
 
   const realHome = realpathSync(home);
-  return join(realHome, ".cireilclaw");
+  return path.join(realHome, ".cireilclaw");
 }
 
 function agentRoot(agentSlug: string): string {
-  return join(root(), "agents", agentSlug);
+  return path.join(root(), "agents", agentSlug);
 }
 
 function resolveMount(
@@ -48,37 +48,37 @@ function resolveMount(
   return undefined;
 }
 
-function sandboxToReal(path: string, agentSlug: string, mounts?: readonly Mount[]): string {
+function sandboxToReal(pth: string, agentSlug: string, mounts?: readonly Mount[]): string {
   const resolved =
-    mounts !== undefined && mounts.length > 0 ? resolveMount(path, mounts) : undefined;
+    mounts !== undefined && mounts.length > 0 ? resolveMount(pth, mounts) : undefined;
 
   if (resolved !== undefined) {
     const { mount, innerPath } = resolved;
-    const realPath = normalize(join(mount.source, innerPath));
-    const relativeToSource = relative(mount.source, realPath);
+    const realPath = path.normalize(path.join(mount.source, innerPath));
+    const relativeToSource = path.relative(mount.source, realPath);
 
-    if (relativeToSource.startsWith("..") || isAbsolute(relativeToSource)) {
-      throw new Error(`Access denied: path '${path}' attempts to escape the mount boundary.`);
+    if (relativeToSource.startsWith("..") || path.isAbsolute(relativeToSource)) {
+      throw new Error(`Access denied: path '${pth}' attempts to escape the mount boundary.`);
     }
 
     const segments: string[] = [];
     let current = realPath;
 
     while (!existsSync(current)) {
-      segments.unshift(basename(current));
-      const parent = dirname(current);
+      segments.unshift(path.basename(current));
+      const parent = path.dirname(current);
       if (parent === current) {
-        throw new Error(`Access denied: no resolvable ancestor for '${path}'`);
+        throw new Error(`Access denied: no resolvable ancestor for '${pth}'`);
       }
       current = parent;
     }
 
     const resolvedBase = realpathSync(current);
-    const fullResolved = join(resolvedBase, ...segments);
-    const realRelative = relative(mount.source, fullResolved);
+    const fullResolved = path.join(resolvedBase, ...segments);
+    const realRelative = path.relative(mount.source, fullResolved);
 
-    if (realRelative.startsWith("..") || isAbsolute(realRelative)) {
-      throw new Error(`Access denied: path '${path}' resolves outside the mount via symlink.`);
+    if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+      throw new Error(`Access denied: path '${pth}' resolves outside the mount via symlink.`);
     }
 
     return fullResolved;
@@ -90,60 +90,60 @@ function sandboxToReal(path: string, agentSlug: string, mounts?: readonly Mount[
   let expectedSubdir: "blocks" | "memories" | "skills" | "tasks" | "workspace" | undefined =
     undefined;
 
-  if (path === "/blocks" || path.startsWith("/blocks/")) {
+  if (pth === "/blocks" || pth.startsWith("/blocks/")) {
     expectedSubdir = "blocks";
-    sandboxPath = join(origin, "blocks", path.slice("/blocks".length));
-  } else if (path === "/memories" || path.startsWith("/memories/")) {
+    sandboxPath = path.join(origin, "blocks", pth.slice("/blocks".length));
+  } else if (pth === "/memories" || pth.startsWith("/memories/")) {
     expectedSubdir = "memories";
-    sandboxPath = join(origin, "memories", path.slice("/memories".length));
-  } else if (path === "/skills" || path.startsWith("/skills/")) {
+    sandboxPath = path.join(origin, "memories", pth.slice("/memories".length));
+  } else if (pth === "/skills" || pth.startsWith("/skills/")) {
     expectedSubdir = "skills";
-    sandboxPath = join(origin, "skills", path.slice("/skills".length));
-  } else if (path === "/tasks" || path.startsWith("/tasks/")) {
+    sandboxPath = path.join(origin, "skills", pth.slice("/skills".length));
+  } else if (pth === "/tasks" || pth.startsWith("/tasks/")) {
     expectedSubdir = "tasks";
-    sandboxPath = join(origin, "tasks", path.slice("/tasks".length));
-  } else if (path === "/workspace" || path.startsWith("/workspace/")) {
+    sandboxPath = path.join(origin, "tasks", pth.slice("/tasks".length));
+  } else if (pth === "/workspace" || pth.startsWith("/workspace/")) {
     expectedSubdir = "workspace";
-    sandboxPath = join(origin, "workspace", path.slice("/workspace".length));
+    sandboxPath = path.join(origin, "workspace", pth.slice("/workspace".length));
   } else {
-    throw new Error(`Access denied: path '${path}' is outside the sandbox.`);
+    throw new Error(`Access denied: path '${pth}' is outside the sandbox.`);
   }
 
-  const normalizedPath = normalize(sandboxPath);
-  const relativePath = relative(origin, normalizedPath);
+  const normalizedPath = path.normalize(sandboxPath);
+  const relativePath = path.relative(origin, normalizedPath);
 
   if (relativePath.startsWith("..")) {
-    throw new Error(`Access denied: path '${path}' attempts to escape the sandbox.`);
+    throw new Error(`Access denied: path '${pth}' attempts to escape the sandbox.`);
   }
 
   if (!relativePath.startsWith(`${expectedSubdir}/`) && relativePath !== expectedSubdir) {
-    throw new Error(`Access denied: path '${path}' escaped the ${expectedSubdir} sandbox area.`);
+    throw new Error(`Access denied: path '${pth}' escaped the ${expectedSubdir} sandbox area.`);
   }
 
   const segments: string[] = [];
   let current = normalizedPath;
 
   while (!existsSync(current)) {
-    segments.unshift(basename(current));
-    const parent = dirname(current);
+    segments.unshift(path.basename(current));
+    const parent = path.dirname(current);
     if (parent === current) {
-      throw new Error(`Access denied: no resolvable ancestor for '${path}'`);
+      throw new Error(`Access denied: no resolvable ancestor for '${pth}'`);
     }
     current = parent;
   }
 
   const resolvedBase = realpathSync(current);
-  const fullResolved = join(resolvedBase, ...segments);
+  const fullResolved = path.join(resolvedBase, ...segments);
   const realOrigin = realpathSync(origin);
-  const realRelative = relative(realOrigin, fullResolved);
+  const realRelative = path.relative(realOrigin, fullResolved);
 
-  if (realRelative.startsWith("..") || isAbsolute(realRelative)) {
-    throw new Error(`Access denied: path '${path}' resolves outside the sandbox via symlink.`);
+  if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+    throw new Error(`Access denied: path '${pth}' resolves outside the sandbox via symlink.`);
   }
 
   if (!realRelative.startsWith(`${expectedSubdir}/`) && realRelative !== expectedSubdir) {
     throw new Error(
-      `Access denied: path '${path}' escaped the ${expectedSubdir} sandbox area via symlink.`,
+      `Access denied: path '${pth}' escaped the ${expectedSubdir} sandbox area via symlink.`,
     );
   }
 
@@ -239,18 +239,18 @@ function checkConditionalAccess(
 // /bin is intentionally excluded — it is a synthetic sandbox dir, not a real host path.
 const EXEC_VISIBLE_PREFIXES = ["/usr", "/lib", "/lib64", "/nix"] as const;
 
-function validateSystemPath(path: string): string {
-  if (path.includes("..")) {
-    throw new Error(`Access denied: path '${path}' contains path traversal.`);
+function validateSystemPath(pth: string): string {
+  if (pth.includes("..")) {
+    throw new Error(`Access denied: path '${pth}' contains path traversal.`);
   }
 
-  const normalized = normalize(path);
+  const normalized = path.normalize(pth);
   const isAllowed = EXEC_VISIBLE_PREFIXES.some(
     (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
   );
 
   if (!isAllowed) {
-    throw new Error(`Access denied: path '${path}' is outside the sandbox.`);
+    throw new Error(`Access denied: path '${pth}' is outside the sandbox.`);
   }
 
   if (!existsSync(normalized)) {
@@ -263,7 +263,7 @@ function validateSystemPath(path: string): string {
   );
 
   if (!isResolvedAllowed) {
-    throw new Error(`Access denied: path '${path}' resolves outside the sandbox via symlink.`);
+    throw new Error(`Access denied: path '${pth}' resolves outside the sandbox via symlink.`);
   }
 
   return resolved;

--- a/packages/runtime/src/util/sandbox.ts
+++ b/packages/runtime/src/util/sandbox.ts
@@ -1,7 +1,7 @@
 // oxlint-disable promise/no-multiple-resolved
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { parse, isAbsolute, join, resolve as resolvePath, delimiter } from "node:path";
+import path from "node:path";
 
 import type { Mount, SandboxConfig } from "#config/schemas/sandbox.js";
 import { debug, warning } from "#output/log.js";
@@ -9,14 +9,14 @@ import { debug, warning } from "#output/log.js";
 import { root } from "./paths.js";
 
 function locate(command: string, pathEnvOverride?: string[]): string | undefined {
-  if (isAbsolute(command)) {
+  if (path.isAbsolute(command)) {
     return existsSync(command) ? command : undefined;
   }
 
-  const path = parse(command);
+  const pth = path.parse(command);
 
   // lgtm[js/path-traversal] - Linux-only (NixOS), forward slashes only
-  for (const segment of path.dir.split("/")) {
+  for (const segment of pth.dir.split("/")) {
     if (segment.length === 0) {
       continue;
     }
@@ -26,10 +26,10 @@ function locate(command: string, pathEnvOverride?: string[]): string | undefined
     }
   }
 
-  const pathEnv = pathEnvOverride ?? (process.env["PATH"] ?? "").split(delimiter);
+  const pathEnv = pathEnvOverride ?? (process.env["PATH"] ?? "").split(path.delimiter);
 
   for (const pathEntry of pathEnv) {
-    const joined = resolvePath(join(pathEntry, command));
+    const joined = path.resolve(path.join(pathEntry, command));
 
     if (existsSync(joined)) {
       return joined;
@@ -79,16 +79,16 @@ function buildCommonArgs(home: string, agentSlug: string): string[] {
     "--hostname",
     `${agentSlug}-sandbox`,
     "--bind",
-    join(home, ".cireilclaw", "agents", agentSlug, "workspace"),
+    path.join(home, ".cireilclaw", "agents", agentSlug, "workspace"),
     "/workspace",
     "--bind",
-    join(home, ".cireilclaw", "agents", agentSlug, "memories"),
+    path.join(home, ".cireilclaw", "agents", agentSlug, "memories"),
     "/memories",
     "--bind",
-    join(home, ".cireilclaw", "agents", agentSlug, "skills"),
+    path.join(home, ".cireilclaw", "agents", agentSlug, "skills"),
     "/skills",
     "--bind",
-    join(home, ".cireilclaw", "agents", agentSlug, "tasks"),
+    path.join(home, ".cireilclaw", "agents", agentSlug, "tasks"),
     "/tasks",
     "--size",
     String(TMPFS_SIZE_BYTES),
@@ -137,7 +137,7 @@ interface EnvParseError {
   hint?: string;
 }
 
-const ENV_VAR_PATTERN = /\$\{(\w+)(?::-([^}]*))?\}|\$(\w+)/g;
+const ENV_VAR_PATTERN = /\$\{(\w+)(?::-([^}]*))?\}|\$(\w+)/gu;
 
 class EnvResolutionError extends Error {
   public override name = "EnvResolutionError";
@@ -387,13 +387,13 @@ async function buildNixBindings(args: string[], binaries: string[]): Promise<boo
 
   const uniquePaths = new Set<string>();
   for (const [, data] of storePaths) {
-    for (const path of data.requisites) {
-      uniquePaths.add(path);
+    for (const pth of data.requisites) {
+      uniquePaths.add(pth);
     }
   }
 
-  for (const path of uniquePaths) {
-    args.push("--ro-bind", path, path);
+  for (const pth of uniquePaths) {
+    args.push("--ro-bind", pth, pth);
   }
 
   for (const [key, data] of storePaths) {
@@ -412,9 +412,9 @@ async function buildNixBindings(args: string[], binaries: string[]): Promise<boo
   if (envBinPath !== undefined) {
     const envResult = await queryNixStore(envBinPath);
     if (envResult.success) {
-      for (const path of envResult.requisites) {
-        if (!uniquePaths.has(path)) {
-          args.push("--ro-bind", path, path);
+      for (const pth of envResult.requisites) {
+        if (!uniquePaths.has(pth)) {
+          args.push("--ro-bind", pth, pth);
         }
       }
       args.push("--dir", "/usr");
@@ -494,7 +494,7 @@ async function buildBwrap(
     };
   }
 
-  if (!isAbsolute(home)) {
+  if (!path.isAbsolute(home)) {
     warning("$HOME is not an absolute path");
     return { message: "$HOME is not an absolute path", type: "error" };
   }
@@ -527,7 +527,7 @@ async function buildBwrap(
   addEtcBindings(args);
   addSslCertificates(args);
 
-  const envPath = join(root(), "agents", agentSlug, "workspace", ".env");
+  const envPath = path.join(root(), "agents", agentSlug, "workspace", ".env");
   const envResult = parseEnvFile(envPath);
 
   if (!Array.isArray(envResult)) {
@@ -656,7 +656,7 @@ async function runRaw(
   return captureExec(proc, timeout);
 }
 
-const SHELL_METACHAR_PATTERN = /[\s"'|&;$`\\]/;
+const SHELL_METACHAR_PATTERN = /[\s"'|&;$`\\]/u;
 
 async function exec(cfg: ExecConfig): Promise<ExecResult> {
   const { binaries, command, args, hostEnvPassthrough, timeout, agentSlug, devices, mounts } = cfg;
@@ -697,7 +697,7 @@ async function exec(cfg: ExecConfig): Promise<ExecResult> {
       };
     }
 
-    const envPath = join(root(), "agents", agentSlug, "workspace", ".env");
+    const envPath = path.join(root(), "agents", agentSlug, "workspace", ".env");
     const envResult = parseEnvFile(envPath);
 
     if (!Array.isArray(envResult)) {

--- a/packages/runtime/src/util/shutdown.ts
+++ b/packages/runtime/src/util/shutdown.ts
@@ -2,18 +2,18 @@ import { warning } from "#output/log.js";
 
 type ShutdownHook = () => void;
 
-const _hooks: ShutdownHook[] = [];
-let _registered = false;
+const hooks: ShutdownHook[] = [];
+let registered = false;
 
 function onShutdown(hook: ShutdownHook): void {
-  _hooks.push(hook);
+  hooks.push(hook);
 }
 
 function registerSigint(): void {
-  if (_registered) {
+  if (registered) {
     return;
   }
-  _registered = true;
+  registered = true;
 
   process.on("SIGINT", () => {
     process.on("SIGINT", () => {
@@ -21,7 +21,7 @@ function registerSigint(): void {
       process.exit(1);
     });
 
-    for (const hook of _hooks) {
+    for (const hook of hooks) {
       try {
         hook();
       } catch {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,8 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "types": "./dist/index.d.mts",
@@ -25,8 +26,7 @@
       },
       "./package.json": "./package.json"
     },
-    "main": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",
@@ -36,11 +36,13 @@
     "@noble/hashes": "^2.2.0",
     "heic-decode": "^2.1.0",
     "sharp": "^0.34.5",
-    "valibot": "^1.3.1"
+    "valibot": "^1.4.1"
   },
   "devDependencies": {
-    "@types/heic-decode": "^1.1.3",
-    "tsdown": "^0.21.10",
+    "@types/heic-decode": "^2.0.0",
+    "node-addon-api": "^8.8.0",
+    "node-gyp": "^12.3.0",
+    "tsdown": "^0.22.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/sdk/src/image.ts
+++ b/packages/sdk/src/image.ts
@@ -35,8 +35,7 @@ async function toWebp(data: ArrayBuffer, mediaType?: string): Promise<Uint8Array
       // implementation calls `.slice()` and spreads the result, which only
       // works on typed arrays. Wrapping in Uint8Array fixes the runtime error;
       // the cast silences the type mismatch.
-      // oxlint-disable-next-line no-unsafe-type-assertion
-      buffer: new Uint8Array(data) as unknown as ArrayBufferLike,
+      buffer: new Uint8Array(data),
     });
     const result = await sharp(Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength), {
       raw: { channels: 4, height, width },

--- a/packages/sdk/src/tool.ts
+++ b/packages/sdk/src/tool.ts
@@ -41,30 +41,30 @@ interface PluginToolContext {
   session: BasicSession;
   agentSlug: string;
   reply: {
-    send: (content: string, attachments?: string[]) => Promise<void>;
-    react?: (emoji: string, messageId?: string) => Promise<void>;
+    send(this: void, content: string, attachments?: string[]): Promise<void>;
+    react?(this: void, emoji: string, messageId?: string): Promise<void>;
   };
   channel: {
-    resolveChannel: (spec: string) => Promise<ChannelResolution>;
+    resolveChannel(this: void, spec: string): Promise<ChannelResolution>;
   };
   cfg: {
-    globalPlugin: (name: string) => Promise<Record<string, unknown> | undefined>;
-    agentPlugin: (name: string) => Promise<Record<string, unknown> | undefined>;
+    globalPlugin(this: void, name: string): Promise<Record<string, unknown> | undefined>;
+    agentPlugin(this: void, name: string): Promise<Record<string, unknown> | undefined>;
   };
-  createKeyPool: (keys: string | string[], cooldownMs?: number) => KeyPool;
+  createKeyPool(this: void, keys: string | string[], cooldownMs?: number): KeyPool;
   // Plugins should use ctx.net.fetch instead of the global fetch. This is the mediation point
   // for future isolation (worker/subprocess); today it's a passthrough.
   net: {
     fetch: typeof fetch;
   };
   mounts?: readonly Mount[];
-  addImage: (data: Uint8Array, mediaType: string) => void;
-  addVideo: (data: Uint8Array, mediaType: string) => void;
-  addToolMessage: (content: string) => void;
+  addImage(this: void, data: Uint8Array, mediaType: string): void;
+  addVideo(this: void, data: Uint8Array, mediaType: string): void;
+  addToolMessage(this: void, content: string): void;
   paths: {
-    resolve: (sandboxPath: string) => Promise<string>;
-    checkWriteAccess: (sandboxPath: string) => Promise<void>;
-    checkConditionalAccess: (sandboxPath: string) => Promise<void>;
+    resolve(this: void, sandboxPath: string): Promise<string>;
+    checkWriteAccess(this: void, sandboxPath: string): Promise<void>;
+    checkConditionalAccess(this: void, sandboxPath: string): Promise<void>;
   };
 }
 

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -13,15 +13,15 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
     },
-    "main": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@cireilclaw/sdk": "workspace:*",
-    "tsdown": "^0.21.10",
+    "tsdown": "^0.22.1",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       oxfmt:
-        specifier: ^0.46.0
-        version: 0.46.0
+        specifier: ^0.53.0
+        version: 0.53.0
       oxlint:
-        specifier: ^1.61.0
-        version: 1.61.0(oxlint-tsgolint@0.21.1)
+        specifier: ^1.68.0
+        version: 1.68.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.23.0
+        version: 0.23.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -27,8 +27,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(typescript@6.0.3)
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(typescript@6.0.3)
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -51,8 +51,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@inquirer/prompts':
-        specifier: ^8.4.2
-        version: 8.4.3(@types/node@25.9.1)
+        specifier: ^8.5.2
+        version: 8.5.2(@types/node@25.9.1)
       '@noble/hashes':
         specifier: ^2.2.0
         version: 2.2.0
@@ -61,7 +61,7 @@ importers:
         version: 1.2.7
       '@valibot/to-json-schema':
         specifier: ^1.6.0
-        version: 1.7.0(valibot@1.4.0(typescript@6.0.3))
+        version: 1.7.0(valibot@1.4.1(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.10.0
@@ -73,31 +73,31 @@ importers:
         version: 10.0.1
       drizzle-orm:
         specifier: 1.0.0-beta.20
-        version: 1.0.0-beta.20(@types/better-sqlite3@7.6.13)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-sqlite3@12.10.0)(mssql@11.0.1(@azure/core-client@1.10.1))(valibot@1.4.0(typescript@6.0.3))
+        version: 1.0.0-beta.20(@types/better-sqlite3@7.6.13)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-sqlite3@12.10.0)(mssql@11.0.1(@azure/core-client@1.10.1))(valibot@1.4.1(typescript@6.0.3))
       heic-decode:
         specifier: ^2.1.0
         version: 2.1.0
       ink:
-        specifier: ^7.0.1
-        version: 7.0.3(@types/react@19.2.15)(react@19.2.6)
+        specifier: ^7.0.5
+        version: 7.0.5(@types/react@19.2.16)(react@19.2.7)
       ink-multiline-input:
         specifier: ^0.1.0
-        version: 0.1.0(ink@7.0.3(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        version: 0.1.0(ink@7.0.5(@types/react@19.2.16)(react@19.2.7))(react@19.2.7)
       ink-spinner:
         specifier: ^5.0.0
-        version: 5.0.0(ink@7.0.3(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+        version: 5.0.0(ink@7.0.5(@types/react@19.2.16)(react@19.2.7))(react@19.2.7)
       oceanic.js:
         specifier: ^1.14.0
         version: 1.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       openai:
-        specifier: ^6.34.0
-        version: 6.39.0(ws@8.21.0)
+        specifier: ^6.42.0
+        version: 6.42.0(ws@8.21.0)
       ora:
         specifier: ^9.4.0
         version: 9.4.0
       react:
-        specifier: ^19.2.5
-        version: 19.2.6
+        specifier: ^19.2.7
+        version: 19.2.7
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -105,8 +105,8 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1
       valibot:
-        specifier: ^1.3.1
-        version: 1.4.0(typescript@6.0.3)
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.9.0
@@ -115,26 +115,32 @@ importers:
         specifier: ^7.6.13
         version: 7.6.13
       '@types/heic-decode':
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.1
       '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.15
+        specifier: ^19.2.16
+        version: 19.2.16
       drizzle-kit:
         specifier: 1.0.0-beta.20
         version: 1.0.0-beta.20
+      node-addon-api:
+        specifier: ^8.8.0
+        version: 8.8.0
+      node-gyp:
+        specifier: ^12.3.0
+        version: 12.3.0
       tsx:
-        specifier: ^4.21.0
-        version: 4.22.3
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/sdk:
     dependencies:
@@ -148,15 +154,21 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       valibot:
-        specifier: ^1.3.1
-        version: 1.4.0(typescript@6.0.3)
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@6.0.3)
     devDependencies:
       '@types/heic-decode':
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^2.0.0
+        version: 2.0.0
+      node-addon-api:
+        specifier: ^8.8.0
+        version: 8.8.0
+      node-gyp:
+        specifier: ^12.3.0
+        version: 12.3.0
       tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(typescript@6.0.3)
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -167,8 +179,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       tsdown:
-        specifier: ^0.21.10
-        version: 0.21.10(typescript@6.0.3)
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -250,26 +262,26 @@ packages:
     resolution: {integrity: sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==}
     engines: {node: '>=20'}
 
-  '@babel/generator@8.0.0-rc.3':
-    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-string-parser@8.0.0-rc.5':
-    resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
+  '@babel/generator@8.0.0-rc.6':
+    resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.3':
-    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  '@babel/helper-string-parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@babel/parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  '@babel/helper-validator-identifier@8.0.0-rc.6':
+    resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
-  '@babel/types@8.0.0-rc.3':
-    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  '@babel/types@8.0.0-rc.6':
+    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@discordjs/voice@0.19.2':
     resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
@@ -629,89 +641,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -736,139 +764,143 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/ansi@2.0.5':
-    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/checkbox@5.1.5':
-    resolution: {integrity: sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@6.0.13':
-    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@11.1.10':
-    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@5.1.2':
-    resolution: {integrity: sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@5.0.14':
-    resolution: {integrity: sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@3.0.0':
-    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@2.0.5':
-    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/input@5.0.13':
-    resolution: {integrity: sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/number@4.0.13':
-    resolution: {integrity: sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/password@5.0.13':
-    resolution: {integrity: sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@8.4.3':
-    resolution: {integrity: sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@5.2.9':
-    resolution: {integrity: sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/search@4.1.9':
-    resolution: {integrity: sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/select@5.1.5':
-    resolution: {integrity: sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/type@4.0.5':
-    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -900,266 +932,282 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
-    resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
+  '@oxc-project/types@0.134.0':
+    resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
+
+  '@oxfmt/binding-android-arm-eabi@0.53.0':
+    resolution: {integrity: sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.46.0':
-    resolution: {integrity: sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==}
+  '@oxfmt/binding-android-arm64@0.53.0':
+    resolution: {integrity: sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
-    resolution: {integrity: sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==}
+  '@oxfmt/binding-darwin-arm64@0.53.0':
+    resolution: {integrity: sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
-    resolution: {integrity: sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==}
+  '@oxfmt/binding-darwin-x64@0.53.0':
+    resolution: {integrity: sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
-    resolution: {integrity: sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==}
+  '@oxfmt/binding-freebsd-x64@0.53.0':
+    resolution: {integrity: sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
-    resolution: {integrity: sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
+    resolution: {integrity: sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
-    resolution: {integrity: sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
+    resolution: {integrity: sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
-    resolution: {integrity: sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
+    resolution: {integrity: sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
-    resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
+  '@oxfmt/binding-linux-arm64-musl@0.53.0':
+    resolution: {integrity: sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
-    resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
+    resolution: {integrity: sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
-    resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
+    resolution: {integrity: sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
-    resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
+  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
+    resolution: {integrity: sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
-    resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
+  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
+    resolution: {integrity: sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
-    resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
+  '@oxfmt/binding-linux-x64-gnu@0.53.0':
+    resolution: {integrity: sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
-    resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
+  '@oxfmt/binding-linux-x64-musl@0.53.0':
+    resolution: {integrity: sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
-    resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
+  '@oxfmt/binding-openharmony-arm64@0.53.0':
+    resolution: {integrity: sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
-    resolution: {integrity: sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==}
+  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
+    resolution: {integrity: sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
-    resolution: {integrity: sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==}
+  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
+    resolution: {integrity: sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
-    resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
+  '@oxfmt/binding-win32-x64-msvc@0.53.0':
+    resolution: {integrity: sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.21.1':
-    resolution: {integrity: sha512-7TLjyWe4wG9saJc992VWmaHq2hwKfOEEVTjheReXJXaDhavMZI4X9a6nKhbEng4IVkYtzjD2jw16vw2WFXLYLw==}
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.21.1':
-    resolution: {integrity: sha512-7wf9Wf75nTzA7zpL9myhFe2RKvfuqGUOADNvUooCjEWvh7hmPz3lSEqTMh5Z/VQhzsG04mM9ACyghxhRzq7zFw==}
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.21.1':
-    resolution: {integrity: sha512-IPuQN/Vd0Rjklg/cCGBbQyUuRBp2f6LQXpZYwk5ivOR6V/+CgiYsv8pn/PVY7gjeyoNvPQrXB7xMjHUO2YZbdw==}
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.21.1':
-    resolution: {integrity: sha512-d1niGuTbh2qiv7dR7tqkbOcM5cIR63of0lMBFdEQavL1KrJV8zuRdwdi68K7MNGdgoR+J5A9ajpGGvsHwp1bPg==}
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.21.1':
-    resolution: {integrity: sha512-ICu9y2JLnFPvFqstnWPPNqBM8LK8BWw2OTeaR0UgEMm4hOSbrZAKv1/hwZYyiLqnCNjBL87AGSQIgTHCYlsipw==}
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.21.1':
-    resolution: {integrity: sha512-cTEFCFjCj6iXfrSHcvajSPNqhEA4TxSzU3gFxbdGSAUTNXGToU99IbdhWAPSbhcucoym0XE4Zl7E41NiSkNTug==}
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.61.0':
-    resolution: {integrity: sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==}
+  '@oxlint/binding-android-arm-eabi@1.68.0':
+    resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.61.0':
-    resolution: {integrity: sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==}
+  '@oxlint/binding-android-arm64@1.68.0':
+    resolution: {integrity: sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.61.0':
-    resolution: {integrity: sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==}
+  '@oxlint/binding-darwin-arm64@1.68.0':
+    resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.61.0':
-    resolution: {integrity: sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==}
+  '@oxlint/binding-darwin-x64@1.68.0':
+    resolution: {integrity: sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.61.0':
-    resolution: {integrity: sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==}
+  '@oxlint/binding-freebsd-x64@1.68.0':
+    resolution: {integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
-    resolution: {integrity: sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
+    resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
-    resolution: {integrity: sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+    resolution: {integrity: sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.61.0':
-    resolution: {integrity: sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==}
+  '@oxlint/binding-linux-arm64-gnu@1.68.0':
+    resolution: {integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.61.0':
-    resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
+  '@oxlint/binding-linux-arm64-musl@1.68.0':
+    resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
-    resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
+  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
+    resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
-    resolution: {integrity: sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==}
+  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+    resolution: {integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.61.0':
-    resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
+  '@oxlint/binding-linux-riscv64-musl@1.68.0':
+    resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.61.0':
-    resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
+  '@oxlint/binding-linux-s390x-gnu@1.68.0':
+    resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.61.0':
-    resolution: {integrity: sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==}
+  '@oxlint/binding-linux-x64-gnu@1.68.0':
+    resolution: {integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.61.0':
-    resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
+  '@oxlint/binding-linux-x64-musl@1.68.0':
+    resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.61.0':
-    resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
+  '@oxlint/binding-openharmony-arm64@1.68.0':
+    resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.61.0':
-    resolution: {integrity: sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==}
+  '@oxlint/binding-win32-arm64-msvc@1.68.0':
+    resolution: {integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.61.0':
-    resolution: {integrity: sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==}
+  '@oxlint/binding-win32-ia32-msvc@1.68.0':
+    resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.61.0':
-    resolution: {integrity: sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==}
+  '@oxlint/binding-win32-x64-msvc@1.68.0':
+    resolution: {integrity: sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1167,23 +1215,17 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+  '@rolldown/binding-android-arm64@1.1.0':
+    resolution: {integrity: sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.0.2':
     resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
@@ -1191,10 +1233,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+  '@rolldown/binding-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.2':
@@ -1203,11 +1245,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+  '@rolldown/binding-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [freebsd]
+    os: [darwin]
 
   '@rolldown/binding-freebsd-x64@1.0.2':
     resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
@@ -1215,11 +1257,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+  '@rolldown/binding-freebsd-x64@1.1.0':
+    resolution: {integrity: sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    cpu: [x64]
+    os: [freebsd]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
@@ -1227,10 +1269,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
+    resolution: {integrity: sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [arm]
     os: [linux]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
@@ -1238,72 +1280,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
+    resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
+    resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
+    cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
+    resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
+    cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
+    resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
+    resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+  '@rolldown/binding-linux-x64-musl@1.1.0':
+    resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -1311,21 +1365,21 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+  '@rolldown/binding-openharmony-arm64@1.1.0':
+    resolution: {integrity: sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.2':
     resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+  '@rolldown/binding-wasm32-wasi@1.1.0':
+    resolution: {integrity: sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
+    cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
     resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
@@ -1333,10 +1387,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
+    resolution: {integrity: sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.2':
@@ -1345,8 +1399,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
+    resolution: {integrity: sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -1392,24 +1449,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@snazzah/davey-linux-arm64-musl@0.1.11':
     resolution: {integrity: sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@snazzah/davey-linux-x64-gnu@0.1.11':
     resolution: {integrity: sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@snazzah/davey-linux-x64-musl@0.1.11':
     resolution: {integrity: sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@snazzah/davey-wasm32-wasi@0.1.11':
     resolution: {integrity: sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==}
@@ -1462,8 +1523,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/heic-decode@1.1.3':
-    resolution: {integrity: sha512-n+wgSmA/yDZ0tu/dh5uq7Orfh/bhaIBd7cpeRtC9FfuICZb8tlU2gYDNbt66x9tNl5yQA+HR1QXBOxHYu9higg==}
+  '@types/heic-decode@2.0.0':
+    resolution: {integrity: sha512-Zj/zngTwbbIE84GsJ9hBI3VmvQRGOe65QV/xVdmLEAGB9bswOBxTMhQVcqNLcxnQhzOmAro5KBg7trrLaYe5Jg==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -1474,8 +1535,8 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
-  '@types/react@19.2.15':
-    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+  '@types/react@19.2.16':
+    resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
 
   '@types/readable-stream@4.0.23':
     resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
@@ -1492,11 +1553,11 @@ packages:
     peerDependencies:
       valibot: ^1.4.0
 
-  '@vitest/expect@4.1.7':
-    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.7':
-    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1506,20 +1567,24 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.7':
-    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.7':
-    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.7':
-    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.7':
-    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.7':
-    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1541,8 +1606,8 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  ansis@4.3.0:
-    resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
   assertion-error@2.0.1:
@@ -1606,6 +1671,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   cli-boxes@4.0.1:
     resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
@@ -1815,9 +1884,9 @@ packages:
       zod:
         optional: true
 
-  dts-resolver@2.1.3:
-    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
-    engines: {node: '>=20.19.0'}
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
     peerDependencies:
       oxc-resolver: '>=11.0.0'
     peerDependenciesMeta:
@@ -1834,6 +1903,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1841,8 +1914,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-toolkit@1.46.1:
-    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1876,6 +1949,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -1913,8 +1989,15 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   heic-decode@2.1.0:
     resolution: {integrity: sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==}
@@ -1942,9 +2025,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  import-without-cache@0.3.3:
-    resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
-    engines: {node: '>=20.19.0'}
+  import-without-cache@0.4.0:
+    resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -1969,8 +2052,8 @@ packages:
       ink: '>=4.0.0'
       react: '>=18.0.0'
 
-  ink@7.0.3:
-    resolution: {integrity: sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==}
+  ink@7.0.5:
+    resolution: {integrity: sha512-zWNjGHQPxSeiSAmDUOq+QPQ6CfmMhmNi85vrJIuy4prafKKUSoZlXEy4wbM7LuLuF1pDURk7qvF4fxrQlLxv3w==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -2012,6 +2095,10 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -2077,24 +2164,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2155,6 +2246,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2185,6 +2284,20 @@ packages:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
+  node-addon-api@8.8.0:
+    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -2207,8 +2320,8 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2223,23 +2336,34 @@ packages:
     resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
 
-  oxfmt@0.46.0:
-    resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  oxlint-tsgolint@0.21.1:
-    resolution: {integrity: sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw==}
-    hasBin: true
-
-  oxlint@1.61.0:
-    resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
+  oxfmt@0.53.0:
+    resolution: {integrity: sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.18.0'
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint-tsgolint@0.23.0:
+    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+    hasBin: true
+
+  oxlint@1.68.0:
+    resolution: {integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   patch-console@2.0.0:
@@ -2283,6 +2407,10 @@ packages:
       opusscript:
         optional: true
 
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -2303,8 +2431,8 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
@@ -2329,13 +2457,13 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
-    engines: {node: '>=20.19.0'}
+  rolldown-plugin-dts@0.25.2:
+    resolution: {integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==}
+    engines: {node: ^22.18.0 || >=24.0.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
-      rolldown: ^1.0.0-rc.12
+      rolldown: ^1.0.0
       typescript: ^5.0.0 || ^6.0.0
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
@@ -2348,13 +2476,13 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.2:
-    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+  rolldown@1.1.0:
+    resolution: {integrity: sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2451,6 +2579,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
+
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
@@ -2470,12 +2602,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -2490,18 +2626,20 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.21.10:
-    resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
-    engines: {node: '>=20.19.0'}
+  tsdown@0.22.1:
+    resolution: {integrity: sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.10
-      '@tsdown/exe': 0.21.10
+      '@tsdown/css': 0.22.1
+      '@tsdown/exe': 0.22.1
       '@vitejs/devtools': '*'
-      publint: ^0.3.0
+      publint: ^0.3.8
+      tsx: '*'
       typescript: ^5.0.0 || ^6.0.0
       unplugin-unused: ^0.5.0
+      unrun: '*'
     peerDependenciesMeta:
       '@arethetypeswrong/core':
         optional: true
@@ -2513,24 +2651,28 @@ packages:
         optional: true
       publint:
         optional: true
+      tsx:
+        optional: true
       typescript:
         optional: true
       unplugin-unused:
+        optional: true
+      unrun:
         optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.3:
-    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  type-fest@5.6.0:
-    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
 
   typescript@6.0.3:
@@ -2544,21 +2686,15 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  unrun@0.2.39:
-    resolution: {integrity: sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
-    peerDependencies:
-      synckit: ^0.11.11
-    peerDependenciesMeta:
-      synckit:
-        optional: true
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.4.0:
-    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -2608,20 +2744,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.7:
-    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.7
-      '@vitest/browser-preview': 4.1.7
-      '@vitest/browser-webdriverio': 4.1.7
-      '@vitest/coverage-istanbul': 4.1.7
-      '@vitest/coverage-v8': 4.1.7
-      '@vitest/ui': 4.1.7
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2648,6 +2784,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2679,6 +2820,10 @@ packages:
 
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
   yaml@2.9.0:
@@ -2843,27 +2988,27 @@ snapshots:
       '@azure/msal-common': 16.6.2
       jsonwebtoken: 9.0.3
 
-  '@babel/generator@8.0.0-rc.3':
+  '@babel/generator@8.0.0-rc.6':
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-string-parser@8.0.0-rc.5': {}
+  '@babel/helper-string-parser@8.0.0-rc.6': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
+  '@babel/helper-validator-identifier@8.0.0-rc.6': {}
 
-  '@babel/parser@8.0.0-rc.3':
+  '@babel/parser@8.0.0-rc.6':
     dependencies:
-      '@babel/types': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.6
 
-  '@babel/types@8.0.0-rc.3':
+  '@babel/types@8.0.0-rc.6':
     dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.5
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/helper-string-parser': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
 
   '@discordjs/voice@0.19.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -3154,29 +3299,29 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/ansi@2.0.5': {}
+  '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.1.5(@types/node@25.9.1)':
+  '@inquirer/checkbox@5.2.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
+  '@inquirer/confirm@6.1.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/core@11.1.10(@types/node@25.9.1)':
+  '@inquirer/core@11.2.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
@@ -3184,94 +3329,98 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/editor@5.1.2(@types/node@25.9.1)':
+  '@inquirer/editor@5.2.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/external-editor': 3.0.0(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/external-editor': 3.0.3(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/expand@5.0.14(@types/node@25.9.1)':
+  '@inquirer/expand@5.1.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/external-editor@3.0.0(@types/node@25.9.1)':
+  '@inquirer/external-editor@3.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/figures@2.0.5': {}
+  '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.0.13(@types/node@25.9.1)':
+  '@inquirer/input@5.1.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/number@4.0.13(@types/node@25.9.1)':
+  '@inquirer/number@4.1.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/password@5.0.13(@types/node@25.9.1)':
+  '@inquirer/password@5.1.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/prompts@8.4.3(@types/node@25.9.1)':
+  '@inquirer/prompts@8.5.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/checkbox': 5.1.5(@types/node@25.9.1)
-      '@inquirer/confirm': 6.0.13(@types/node@25.9.1)
-      '@inquirer/editor': 5.1.2(@types/node@25.9.1)
-      '@inquirer/expand': 5.0.14(@types/node@25.9.1)
-      '@inquirer/input': 5.0.13(@types/node@25.9.1)
-      '@inquirer/number': 4.0.13(@types/node@25.9.1)
-      '@inquirer/password': 5.0.13(@types/node@25.9.1)
-      '@inquirer/rawlist': 5.2.9(@types/node@25.9.1)
-      '@inquirer/search': 4.1.9(@types/node@25.9.1)
-      '@inquirer/select': 5.1.5(@types/node@25.9.1)
+      '@inquirer/checkbox': 5.2.1(@types/node@25.9.1)
+      '@inquirer/confirm': 6.1.1(@types/node@25.9.1)
+      '@inquirer/editor': 5.2.2(@types/node@25.9.1)
+      '@inquirer/expand': 5.1.1(@types/node@25.9.1)
+      '@inquirer/input': 5.1.2(@types/node@25.9.1)
+      '@inquirer/number': 4.1.1(@types/node@25.9.1)
+      '@inquirer/password': 5.1.1(@types/node@25.9.1)
+      '@inquirer/rawlist': 5.3.1(@types/node@25.9.1)
+      '@inquirer/search': 4.2.1(@types/node@25.9.1)
+      '@inquirer/select': 5.2.1(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/rawlist@5.2.9(@types/node@25.9.1)':
+  '@inquirer/rawlist@5.3.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/search@4.1.9(@types/node@25.9.1)':
+  '@inquirer/search@4.2.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/select@5.1.5(@types/node@25.9.1)':
+  '@inquirer/select@5.2.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.9.1)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@inquirer/type@4.0.5(@types/node@25.9.1)':
+  '@inquirer/type@4.0.7(@types/node@25.9.1)':
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3302,223 +3451,216 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@oxc-project/types@0.127.0': {}
-
   '@oxc-project/types@0.132.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
+  '@oxc-project/types@0.134.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.53.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.46.0':
+  '@oxfmt/binding-android-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
+  '@oxfmt/binding-darwin-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
+  '@oxfmt/binding-darwin-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
+  '@oxfmt/binding-freebsd-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+  '@oxfmt/binding-linux-arm64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+  '@oxfmt/binding-linux-x64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
+  '@oxfmt/binding-linux-x64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
+  '@oxfmt/binding-openharmony-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+  '@oxfmt/binding-win32-x64-msvc@0.53.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.21.1':
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.21.1':
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.21.1':
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.21.1':
+  '@oxlint-tsgolint/linux-x64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.21.1':
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.21.1':
+  '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.61.0':
+  '@oxlint/binding-android-arm-eabi@1.68.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.61.0':
+  '@oxlint/binding-android-arm64@1.68.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.61.0':
+  '@oxlint/binding-darwin-arm64@1.68.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.61.0':
+  '@oxlint/binding-darwin-x64@1.68.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.61.0':
+  '@oxlint/binding-freebsd-x64@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.61.0':
+  '@oxlint/binding-linux-arm64-gnu@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.61.0':
+  '@oxlint/binding-linux-arm64-musl@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.61.0':
+  '@oxlint/binding-linux-riscv64-musl@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.61.0':
+  '@oxlint/binding-linux-s390x-gnu@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.61.0':
+  '@oxlint/binding-linux-x64-gnu@1.68.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.61.0':
+  '@oxlint/binding-linux-x64-musl@1.68.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.61.0':
+  '@oxlint/binding-openharmony-arm64@1.68.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.61.0':
+  '@oxlint/binding-win32-arm64-msvc@1.68.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.61.0':
+  '@oxlint/binding-win32-ia32-msvc@1.68.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.61.0':
+  '@oxlint/binding-win32-x64-msvc@1.68.0':
     optional: true
 
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+  '@rolldown/binding-android-arm64@1.1.0':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-arm64@1.1.0':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-x64@1.1.0':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+  '@rolldown/binding-freebsd-x64@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-musl@1.1.0':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+  '@rolldown/binding-openharmony-arm64@1.1.0':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.2':
@@ -3528,19 +3670,24 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-wasm32-wasi@1.1.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.17': {}
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
+    optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -3636,7 +3783,7 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/heic-decode@1.1.3': {}
+  '@types/heic-decode@2.0.0': {}
 
   '@types/jsesc@2.5.1': {}
 
@@ -3653,7 +3800,7 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/react@19.2.15':
+  '@types/react@19.2.16':
     dependencies:
       csstype: 3.2.3
 
@@ -3674,50 +3821,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3))':
     dependencies:
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
 
-  '@vitest/expect@4.1.7':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.7
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.7':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.7':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.7':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.7': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.7':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  abbrev@4.0.0: {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -3733,13 +3882,13 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  ansis@4.3.0: {}
+  ansis@4.3.1: {}
 
   assertion-error@2.0.1: {}
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.6
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -3796,6 +3945,8 @@ snapshots:
   chardet@2.1.1: {}
 
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   cli-boxes@4.0.1: {}
 
@@ -3866,16 +4017,16 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-beta.20(@types/better-sqlite3@7.6.13)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-sqlite3@12.10.0)(mssql@11.0.1(@azure/core-client@1.10.1))(valibot@1.4.0(typescript@6.0.3)):
+  drizzle-orm@1.0.0-beta.20(@types/better-sqlite3@7.6.13)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-sqlite3@12.10.0)(mssql@11.0.1(@azure/core-client@1.10.1))(valibot@1.4.1(typescript@6.0.3)):
     dependencies:
       '@types/mssql': 9.1.11(@azure/core-client@1.10.1)
       mssql: 11.0.1(@azure/core-client@1.10.1)
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.10.0
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
 
-  dts-resolver@2.1.3: {}
+  dts-resolver@3.0.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -3887,11 +4038,13 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
 
   es-module-lexer@2.1.0: {}
 
-  es-toolkit@1.46.1: {}
+  es-toolkit@1.47.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -3965,6 +4118,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3992,7 +4147,13 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-from-package@0.0.0: {}
+
+  graceful-fs@4.2.11: {}
 
   heic-decode@2.1.0:
     dependencies:
@@ -4024,7 +4185,7 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  import-without-cache@0.3.3: {}
+  import-without-cache@0.4.0: {}
 
   indent-string@5.0.0: {}
 
@@ -4032,18 +4193,18 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ink-multiline-input@0.1.0(ink@7.0.3(@types/react@19.2.15)(react@19.2.6))(react@19.2.6):
+  ink-multiline-input@0.1.0(ink@7.0.5(@types/react@19.2.16)(react@19.2.7))(react@19.2.7):
     dependencies:
-      ink: 7.0.3(@types/react@19.2.15)(react@19.2.6)
-      react: 19.2.6
+      ink: 7.0.5(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.7
 
-  ink-spinner@5.0.0(ink@7.0.3(@types/react@19.2.15)(react@19.2.6))(react@19.2.6):
+  ink-spinner@5.0.0(ink@7.0.5(@types/react@19.2.16)(react@19.2.7))(react@19.2.7):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 7.0.3(@types/react@19.2.15)(react@19.2.6)
-      react: 19.2.6
+      ink: 7.0.5(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.7
 
-  ink@7.0.3(@types/react@19.2.15)(react@19.2.6):
+  ink@7.0.5(@types/react@19.2.16)(react@19.2.7):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0
@@ -4054,25 +4215,25 @@ snapshots:
       cli-cursor: 4.0.0
       cli-truncate: 6.0.0
       code-excerpt: 4.0.0
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0
-      react: 19.2.6
-      react-reconciler: 0.33.0(react@19.2.6)
+      react: 19.2.7
+      react-reconciler: 0.33.0(react@19.2.7)
       scheduler: 0.27.0
       signal-exit: 3.0.7
       slice-ansi: 9.0.0
       stack-utils: 2.0.6
       string-width: 8.2.1
       terminal-size: 4.0.1
-      type-fest: 5.6.0
+      type-fest: 5.7.0
       widest-line: 6.0.0
       wrap-ansi: 10.0.0
       ws: 8.21.0
       yoga-layout: 3.2.1
     optionalDependencies:
-      '@types/react': 19.2.15
+      '@types/react': 19.2.16
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4096,6 +4257,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isexe@4.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -4211,6 +4374,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
@@ -4238,6 +4407,25 @@ snapshots:
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.1
+
+  node-addon-api@8.8.0: {}
+
+  node-gyp@12.3.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.8.1
+      tar: 7.5.16
+      tinyglobby: 0.2.16
+      undici: 6.26.0
+      which: 6.0.1
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   obug@2.1.1: {}
 
@@ -4276,7 +4464,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@6.39.0(ws@8.21.0):
+  openai@6.42.0(ws@8.21.0):
     optionalDependencies:
       ws: 8.21.0
 
@@ -4291,61 +4479,61 @@ snapshots:
       stdin-discarder: 0.3.2
       string-width: 8.2.1
 
-  oxfmt@0.46.0:
+  oxfmt@0.53.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.46.0
-      '@oxfmt/binding-android-arm64': 0.46.0
-      '@oxfmt/binding-darwin-arm64': 0.46.0
-      '@oxfmt/binding-darwin-x64': 0.46.0
-      '@oxfmt/binding-freebsd-x64': 0.46.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.46.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.46.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.46.0
-      '@oxfmt/binding-linux-arm64-musl': 0.46.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.46.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-musl': 0.46.0
-      '@oxfmt/binding-openharmony-arm64': 0.46.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.46.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.46.0
-      '@oxfmt/binding-win32-x64-msvc': 0.46.0
+      '@oxfmt/binding-android-arm-eabi': 0.53.0
+      '@oxfmt/binding-android-arm64': 0.53.0
+      '@oxfmt/binding-darwin-arm64': 0.53.0
+      '@oxfmt/binding-darwin-x64': 0.53.0
+      '@oxfmt/binding-freebsd-x64': 0.53.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.53.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.53.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.53.0
+      '@oxfmt/binding-linux-arm64-musl': 0.53.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.53.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.53.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.53.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.53.0
+      '@oxfmt/binding-linux-x64-gnu': 0.53.0
+      '@oxfmt/binding-linux-x64-musl': 0.53.0
+      '@oxfmt/binding-openharmony-arm64': 0.53.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.53.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.53.0
+      '@oxfmt/binding-win32-x64-msvc': 0.53.0
 
-  oxlint-tsgolint@0.21.1:
+  oxlint-tsgolint@0.23.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.21.1
-      '@oxlint-tsgolint/darwin-x64': 0.21.1
-      '@oxlint-tsgolint/linux-arm64': 0.21.1
-      '@oxlint-tsgolint/linux-x64': 0.21.1
-      '@oxlint-tsgolint/win32-arm64': 0.21.1
-      '@oxlint-tsgolint/win32-x64': 0.21.1
+      '@oxlint-tsgolint/darwin-arm64': 0.23.0
+      '@oxlint-tsgolint/darwin-x64': 0.23.0
+      '@oxlint-tsgolint/linux-arm64': 0.23.0
+      '@oxlint-tsgolint/linux-x64': 0.23.0
+      '@oxlint-tsgolint/win32-arm64': 0.23.0
+      '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.61.0(oxlint-tsgolint@0.21.1):
+  oxlint@1.68.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.61.0
-      '@oxlint/binding-android-arm64': 1.61.0
-      '@oxlint/binding-darwin-arm64': 1.61.0
-      '@oxlint/binding-darwin-x64': 1.61.0
-      '@oxlint/binding-freebsd-x64': 1.61.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.61.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.61.0
-      '@oxlint/binding-linux-arm64-gnu': 1.61.0
-      '@oxlint/binding-linux-arm64-musl': 1.61.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.61.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.61.0
-      '@oxlint/binding-linux-riscv64-musl': 1.61.0
-      '@oxlint/binding-linux-s390x-gnu': 1.61.0
-      '@oxlint/binding-linux-x64-gnu': 1.61.0
-      '@oxlint/binding-linux-x64-musl': 1.61.0
-      '@oxlint/binding-openharmony-arm64': 1.61.0
-      '@oxlint/binding-win32-arm64-msvc': 1.61.0
-      '@oxlint/binding-win32-ia32-msvc': 1.61.0
-      '@oxlint/binding-win32-x64-msvc': 1.61.0
-      oxlint-tsgolint: 0.21.1
+      '@oxlint/binding-android-arm-eabi': 1.68.0
+      '@oxlint/binding-android-arm64': 1.68.0
+      '@oxlint/binding-darwin-arm64': 1.68.0
+      '@oxlint/binding-darwin-x64': 1.68.0
+      '@oxlint/binding-freebsd-x64': 1.68.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.68.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.68.0
+      '@oxlint/binding-linux-arm64-gnu': 1.68.0
+      '@oxlint/binding-linux-arm64-musl': 1.68.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.68.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.68.0
+      '@oxlint/binding-linux-riscv64-musl': 1.68.0
+      '@oxlint/binding-linux-s390x-gnu': 1.68.0
+      '@oxlint/binding-linux-x64-gnu': 1.68.0
+      '@oxlint/binding-linux-x64-musl': 1.68.0
+      '@oxlint/binding-openharmony-arm64': 1.68.0
+      '@oxlint/binding-win32-arm64-msvc': 1.68.0
+      '@oxlint/binding-win32-ia32-msvc': 1.68.0
+      '@oxlint/binding-win32-x64-msvc': 1.68.0
+      oxlint-tsgolint: 0.23.0
 
   patch-console@2.0.0: {}
 
@@ -4379,6 +4567,8 @@ snapshots:
   prism-media@1.3.5:
     optional: true
 
+  proc-log@6.1.0: {}
+
   process@0.11.10: {}
 
   pump@3.0.4:
@@ -4395,12 +4585,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-reconciler@0.33.0(react@19.2.6):
+  react-reconciler@0.33.0(react@19.2.7):
     dependencies:
-      react: 19.2.6
+      react: 19.2.7
       scheduler: 0.27.0
 
-  react@19.2.6: {}
+  react@19.2.7: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -4430,44 +4620,21 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3):
+  rolldown-plugin-dts@0.25.2(rolldown@1.1.0)(typescript@6.0.3):
     dependencies:
-      '@babel/generator': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
+      '@babel/generator': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
+      '@babel/parser': 8.0.0-rc.6
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
-      dts-resolver: 2.1.3
-      get-tsconfig: 4.14.0
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
       obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
+      rolldown: 1.1.0
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
-
-  rolldown@1.0.0-rc.17:
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rolldown@1.0.2:
     dependencies:
@@ -4489,6 +4656,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.2
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
+
+  rolldown@1.1.0:
+    dependencies:
+      '@oxc-project/types': 0.134.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.0
+      '@rolldown/binding-darwin-arm64': 1.1.0
+      '@rolldown/binding-darwin-x64': 1.1.0
+      '@rolldown/binding-freebsd-x64': 1.1.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.0
+      '@rolldown/binding-linux-arm64-gnu': 1.1.0
+      '@rolldown/binding-linux-arm64-musl': 1.1.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.0
+      '@rolldown/binding-linux-s390x-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-musl': 1.1.0
+      '@rolldown/binding-openharmony-arm64': 1.1.0
+      '@rolldown/binding-wasm32-wasi': 1.1.0
+      '@rolldown/binding-win32-arm64-msvc': 1.1.0
+      '@rolldown/binding-win32-x64-msvc': 1.1.0
 
   run-applescript@7.1.0: {}
 
@@ -4598,6 +4786,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tarn@3.0.2: {}
 
   tedious@18.6.2(@azure/core-client@1.10.1):
@@ -4636,9 +4832,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -4649,36 +4850,35 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.21.10(typescript@6.0.3):
+  tsdown@0.22.1(tsx@4.22.4)(typescript@6.0.3):
     dependencies:
-      ansis: 4.3.0
+      ansis: 4.3.1
       cac: 7.0.0
       defu: 6.1.7
       empathic: 2.0.1
       hookable: 6.1.1
-      import-without-cache: 0.3.3
+      import-without-cache: 0.4.0
       obug: 2.1.1
       picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3)
+      rolldown: 1.1.0
+      rolldown-plugin-dts: 0.25.2(rolldown@1.1.0)(typescript@6.0.3)
       semver: 7.8.1
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
-      unrun: 0.2.39
     optionalDependencies:
+      tsx: 4.22.4
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
       - oxc-resolver
-      - synckit
       - vue-tsc
 
   tslib@2.8.1: {}
 
-  tsx@4.22.3:
+  tsx@4.22.4:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:
@@ -4688,7 +4888,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  type-fest@5.6.0:
+  type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -4701,40 +4901,38 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  unrun@0.2.39:
-    dependencies:
-      rolldown: 1.0.0-rc.17
+  undici@6.26.0: {}
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.4.0(typescript@6.0.3):
+  valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
       rolldown: 1.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.22.3
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -4743,15 +4941,19 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
     transitivePeerDependencies:
       - msw
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -4775,6 +4977,8 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  yallist@5.0.0: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - "packages/*"
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  sharp: true
 onlyBuiltDependencies:
   - better-sqlite3
   - esbuild


### PR DESCRIPTION
giga-commit, I know, but it's fine:tm:
well, probably. idk i doubt i changed anything enough for it to matter lol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security-Critical Changes

### Path Isolation and Validation
- validateSystemPath parameter renamed to `pth` and error messages now reference `pth` (minor API/text change).
- sandboxToReal and validateSystemPath were substantially rewritten to use Node's path.* helpers (path.normalize/join/relative/realpathSync). They now explicitly:
  - normalize and join paths,
  - walk to existing ancestors,
  - resolve symlinks and reject escapes via `..` or symlink targets.
  These are defensive changes that generally strengthen path isolation but should be audited for symlink-resolution edge cases.
- Many modules switched from named `join`/`basename` imports to the default `node:path` import and `path.join` usage (migrations, loader, db, many runtime modules). This centralizes path handling and reduces join/escape inconsistencies.

### Sandbox and Exec Surface
- SHELL_METACHAR_PATTERN was centralized and strengthened (now includes the Unicode `u` flag) and exec now imports the shared pattern instead of using a local constant. This centralizes and tightens shell metacharacter filtering used by command validation.
- ENV_VAR_PATTERN also gained the `u` flag; env interpolation uses Unicode-aware regexes.
- sandbox-related code (sandbox.ts, sandbox-to-real logic, env-file path construction) was refactored to use `path.join` and Unicode-aware regexes.

### Parsing and Validation (Regex / Unicode)
- Widespread addition of the Unicode `/u` flag across many regexes affecting:
  - slug normalization, trimming, and sanitization (CLI, summarizer, prune, tooling),
  - Discord ID and ownerId validations,
  - Markdown/XML outline extraction and system-prompt section extraction,
  - schedule id validation, listSessions HTML stripping, query/session search matching, and other sanitizers.
- These are primarily correctness/lint improvements but can subtly change validation rules for non-ASCII inputs — review any places where ID/slug/path validation is security-sensitive.

### Type/Signature Changes Affecting Validation Surface
- Several tool/plugin context interfaces and RPC types changed from function-typed properties to method signatures with explicit `this: void` (PluginToolContext, ToolContext, PortLike, RpcChannel internals, ToolContext/ToolContext-reply signatures). These are compile-time typing changes (no direct runtime change) but may cause TypeScript mismatches in plugins or dynamic callsites—verify plugin compatibility and any type-driven callsite generation.

### Structural / Visibility Changes Near Security Boundaries
- Multiple classes had underscored/private internals exposed or renamed to public properties:
  - Agent: private underscored fields → public properties (slug, sessions, channelHandlers, conditions, discordClient, ownerId, scheduler).
  - Harness: singleton `_instance`/`_agents` → `instance` and `public readonly agents`.
  - Scheduler: private fields renamed to non-underscored and internal scheduling helpers renamed (affects heartbeat and cron handle storage).
- This increases the accessible surface for external code to read/modify internal state; audit callsites for unsafe direct access or mutation.

### Filesystem / Logging
- Logging implementation (output/log.ts) refactored:
  - internal state renamed (`_fd`/`_filePath`/`_bytesWritten` → `fd`/`filePath`/`bytesWritten`),
  - rotate/setLogFile reworked to ensure parent dirs, safely close previous descriptors, rotate backups, reopen appended logs, and seed `bytesWritten` from statSync.
- Because this touches file-descriptor handling and path usage, confirm permissions, error handling, and that log file paths cannot be attacker-controlled without validation.

### Package / Build Changes with Security Implications
- Multiple packages changed their published entrypoints from `src` → `dist` and adjusted `exports` maps (brave-search, sdk, template, others).
- Dev/runtime dependency upgrades and pnpm-workspace added allowBuilds for native deps (better-sqlite3, esbuild, sharp). Dependency upgrades can introduce fixes but also behavioral changes—validate CI/build sandboxing and native build behavior.

## Review Recommendations / Concerns
- Because this single "giga-commit" mixes many lint-driven Unicode/regex changes with substantial sandbox/path rewrites and API visibility changes, prioritize focused reviews on:
  - Symlink resolution and ancestor-walk logic in sandboxToReal / validateSystemPath to ensure no regressions allow escapes.
  - Centralized SHELL_METACHAR_PATTERN and exec command validation to confirm legitimate commands remain usable and no unintended blocking occurs.
  - Publicization of Agent/Harness/Scheduler internals: find and audit external callsites that may now access or mutate these fields directly.
  - Type signature changes for plugin/tool contexts: verify third-party plugins and dynamic callsites compile/run; ensure no runtime misuse stems from changed typings.
  - Logging file rotation/opening: verify correct permission handling and that log paths are validated.
  - Unicode regex changes where IDs/slugs/paths are security-relevant — confirm intended acceptance/rejection semantics for non-ASCII input.

Overall, most path/sandbox/parsing changes strengthen normalization and validation, but they change cross-cutting behavior and expand public surface area; perform a focused security review on symlink handling, sandbox escapes, shell validation, and newly-exposed internal state before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->