### PR TITLE
fix: strip regex flags before toJsonSchema conversion (runtime crash on vb.regex with flags)

### DIFF
--- a/packages/runtime/src/engine/provider/anthropic.ts
+++ b/packages/runtime/src/engine/provider/anthropic.ts
@@ -1,5 +1,5 @@
 import type { KeyPool } from "@cireilclaw/sdk";
-import { toJsonSchema } from "@valibot/to-json-schema";
+import { toJsonSchemaSafe } from "#util/schema.js";
 import * as vb from "valibot";
 
 import { DefaultReasoningBudget } from "#config/schemas/engine.js";
@@ -267,7 +267,7 @@ async function translateMessages(
 function translateTool(tool: Tool): Record<string, unknown> {
   const inputSchema =
     tool.jsonSchema ??
-    toJsonSchema(tool.parameters, {
+    toJsonSchemaSafe(tool.parameters, {
       target: "openapi-3.0",
       typeMode: "input",
     });

--- a/packages/runtime/src/engine/provider/anthropic.ts
+++ b/packages/runtime/src/engine/provider/anthropic.ts
@@ -1,5 +1,4 @@
 import type { KeyPool } from "@cireilclaw/sdk";
-import { toJsonSchemaSafe } from "#util/schema.js";
 import * as vb from "valibot";
 
 import { DefaultReasoningBudget } from "#config/schemas/engine.js";
@@ -18,6 +17,7 @@ import type { Tool } from "#engine/tool.js";
 import { debug, warning } from "#output/log.js";
 import { encode } from "#util/base64.js";
 import { scaleForAnthropic } from "#util/image.js";
+import { toJsonSchemaSafe } from "#util/schema.js";
 
 interface AnthropicTextBlock {
   cache_control?: { type: "ephemeral" };

--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 
 import type { KeyPool } from "@cireilclaw/sdk";
-import { toJsonSchemaSafe } from "#util/schema.js";
 import { OpenAI } from "openai/client.js";
 import { APIError } from "openai/error.js";
 import type {
@@ -23,6 +22,7 @@ import { debug, warning } from "#output/log.js";
 import { encode } from "#util/base64.js";
 import { toJpeg } from "#util/image.js";
 import { parseRepairedJSON } from "#util/json.js";
+import { toJsonSchemaSafe } from "#util/schema.js";
 
 // Per-apiBase JPEG requirement flag. Set on first WebP rejection so subsequent
 // turns skip the doomed WebP attempt entirely.

--- a/packages/runtime/src/engine/provider/oai.ts
+++ b/packages/runtime/src/engine/provider/oai.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type { KeyPool } from "@cireilclaw/sdk";
-import { toJsonSchema } from "@valibot/to-json-schema";
+import { toJsonSchemaSafe } from "#util/schema.js";
 import { OpenAI } from "openai/client.js";
 import { APIError } from "openai/error.js";
 import type {
@@ -292,7 +292,7 @@ function translateMsg(message: Message): ChatCompletionMessageParam {
 function translateTool(tool: Tool): ChatCompletionTool {
   const schema =
     tool.jsonSchema ??
-    toJsonSchema(tool.parameters, {
+    toJsonSchemaSafe(tool.parameters, {
       target: "openapi-3.0",
       typeMode: "input",
     });

--- a/packages/runtime/src/engine/provider/openai-codex.ts
+++ b/packages/runtime/src/engine/provider/openai-codex.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { toJsonSchema } from "@valibot/to-json-schema";
+import { toJsonSchemaSafe } from "#util/schema.js";
 import * as vb from "valibot";
 
 import type { ImageContent, RedactedThinkingContent, ToolCallContent } from "#engine/content.js";
@@ -224,7 +224,7 @@ async function translateUserContent(
 function translateTool(tool: Tool): Record<string, unknown> {
   const schema =
     tool.jsonSchema ??
-    toJsonSchema(tool.parameters, {
+    toJsonSchemaSafe(tool.parameters, {
       target: "openapi-3.0",
       typeMode: "input",
     });

--- a/packages/runtime/src/engine/provider/openai-codex.ts
+++ b/packages/runtime/src/engine/provider/openai-codex.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { toJsonSchemaSafe } from "#util/schema.js";
 import * as vb from "valibot";
 
 import type { ImageContent, RedactedThinkingContent, ToolCallContent } from "#engine/content.js";
@@ -12,6 +11,7 @@ import { debug, warning } from "#output/log.js";
 import { encode } from "#util/base64.js";
 import { toJpeg } from "#util/image.js";
 import { parseRepairedJSON } from "#util/json.js";
+import { toJsonSchemaSafe } from "#util/schema.js";
 
 import { getChatGptAccountId, getValidCodexAuth } from "./openai-codex-auth.js";
 

--- a/packages/runtime/src/plugin/worker-main.ts
+++ b/packages/runtime/src/plugin/worker-main.ts
@@ -14,6 +14,7 @@ import type {
   PluginFactory,
   PluginToolContext,
 } from "@cireilclaw/sdk";
+
 import { toJsonSchemaSafe } from "#util/schema.js";
 
 import { RpcChannel } from "./rpc.js";

--- a/packages/runtime/src/plugin/worker-main.ts
+++ b/packages/runtime/src/plugin/worker-main.ts
@@ -14,7 +14,7 @@ import type {
   PluginFactory,
   PluginToolContext,
 } from "@cireilclaw/sdk";
-import { toJsonSchema } from "@valibot/to-json-schema";
+import { toJsonSchemaSafe } from "#util/schema.js";
 
 import { RpcChannel } from "./rpc.js";
 
@@ -199,7 +199,7 @@ async function main(parent: NonNullable<typeof parentPort>, init: WorkerInit): P
     manifestEntries.push({
       description: def.description,
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JsonSchema is structurally compatible with Record<string, unknown>
-      jsonSchema: toJsonSchema(def.parameters, {
+      jsonSchema: toJsonSchemaSafe(def.parameters, {
         target: "openapi-3.0",
         typeMode: "input",
       }) as unknown as Record<string, unknown>,

--- a/packages/runtime/src/util/schema.ts
+++ b/packages/runtime/src/util/schema.ts
@@ -15,6 +15,7 @@ function stripRegexFlags(value: unknown): unknown {
   if (value instanceof RegExp) {
     // Flags like /u are meaningless for JSON Schema pattern. The source is
     // all that matters.
+    // oxlint-disable-next-line eslint/require-unicode-regexp
     return new RegExp(value.source);
   }
   if (Array.isArray(value)) {

--- a/packages/runtime/src/util/schema.ts
+++ b/packages/runtime/src/util/schema.ts
@@ -15,7 +15,6 @@ function stripRegexFlags(value: unknown): unknown {
   if (value instanceof RegExp) {
     // Flags like /u are meaningless for JSON Schema pattern. The source is
     // all that matters.
-    // oxlint-disable-next-line require-unicode-regexp
     return new RegExp(value.source);
   }
   if (Array.isArray(value)) {

--- a/packages/runtime/src/util/schema.ts
+++ b/packages/runtime/src/util/schema.ts
@@ -1,0 +1,46 @@
+import { toJsonSchema } from "@valibot/to-json-schema";
+import type { JsonSchema } from "@valibot/to-json-schema";
+import type { GenericSchema } from "valibot";
+
+/**
+ * Recursively clones a value, replacing any `RegExp` instance with an
+ * equivalent one without flags. Needed because `@valibot/to-json-schema`
+ * throws on regex flags — JSON Schema's `pattern` keyword does not support
+ * them.
+ *
+ * This is a structural clone: known valibot schema shapes are walked so the
+ * result stays isomorphic to the input for valibot's purposes.
+ */
+function stripRegexFlags(value: unknown): unknown {
+  if (value instanceof RegExp) {
+    // Flags like /u are meaningless for JSON Schema pattern. The source is
+    // all that matters.
+    // oxlint-disable-next-line require-unicode-regexp
+    return new RegExp(value.source);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stripRegexFlags(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- valibot schemas are plain dicts
+    const entries = Object.entries(value as Record<string, unknown>);
+    for (const [key, val] of entries) {
+      result[key] = stripRegexFlags(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Converts a Valibot schema to JSON Schema, safely handling any regex
+ * actions that carry flags (which `@valibot/to-json-schema` rejects).
+ */
+export function toJsonSchemaSafe(
+  schema: GenericSchema,
+  config?: Parameters<typeof toJsonSchema>[1],
+): JsonSchema {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return toJsonSchema(stripRegexFlags(schema) as Parameters<typeof toJsonSchema>[0], config);
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - "packages/*"
+allowBuilds:
+  better-sqlite3: set this to true or false
+  esbuild: set this to true or false
+  sharp: set this to true or false
 onlyBuiltDependencies:
   - better-sqlite3
   - esbuild


### PR DESCRIPTION
`@valibot/to-json-schema` rejects RegExp flags — JSON Schema's `pattern` keyword has no flag concept. The `/u` flag on tool parameter regexes (`vb.regex`) triggered a runtime crash in `translateTool`:

```
Error: RegExp flags are not supported by JSON Schema.
    at translateTool (oai.ts:295)
```

Created `toJsonSchemaSafe()` in a new `util/schema.ts` that recursively walks the valibot schema tree, replaces any `RegExp` with a flagless clone, then delegates to `toJsonSchema`. All 4 call sites (`oai`, `anthropic`, `openai-codex`, `worker-main`) now use the safe wrapper.

The `schedule` tool uses `vb.regex(/^[a-z0-9-]+$/u)` in its parameters — this was the primary trigger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security-Critical Analysis: Parsing and Validation Subsystem

This PR adds a safe JSON Schema conversion helper to avoid runtime crashes when Valibot schemas include RegExp objects with flags. The changes are parsing/validation-adjacent and should be reviewed for the contract described below.

### What changed
- New helper: packages/runtime/src/util/schema.ts
  - export function toJsonSchemaSafe(schema: GenericSchema, config?: Parameters<typeof toJsonSchema>[1]): JsonSchema
  - Implements stripRegexFlags(schema) which recursively clones the Valibot schema and replaces any RegExp instances with clones that drop all flags, then calls `@valibot/to-json-schema` on the sanitized schema.
- Replaced direct calls to `@valibot/to-json-schema` with toJsonSchemaSafe in:
  - packages/runtime/src/engine/provider/oai.ts
  - packages/runtime/src/engine/provider/anthropic.ts
  - packages/runtime/src/engine/provider/openai-codex.ts
  - packages/runtime/src/plugin/worker-main.ts

These locations are all on the tool translation / manifest generation path (schemas sent to LLM providers or included in worker manifests).

### Security/Validation impact
- Runtime validation in the codebase still uses vb.parse() with the original Valibot schemas (including regex flags). The repo contains many vb.parse usages (including schedule.ts, discord/heartbeat related schemas) — i.e., validation continues to run against flag-bearing regexes.
- stripRegexFlags is used only for JSON Schema generation (output to external providers), not for internal vb.parse validation. Thus, validation semantics remain unchanged in current code paths.
- The PR enforces an implicit contract: sanitized schemas (with flags removed) must not be reused for internal validation. If that contract is violated in the future, it could weaken validation for patterns where flags change semantics (notably Unicode /u, case-insensitive /i, multiline /m).

### Recommendation / notes
- The change appropriately scopes flag-stripping to JSON Schema conversion and prevents the crash ("RegExp flags are not supported by JSON Schema.") when tool schemas include flagged RegExps.
- Reviewers should ensure future contributors do not accidentally use the sanitized schema for validation. Consider documenting the intended use of toJsonSchemaSafe in code comments or module README to reduce the risk of misuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->