### PR TITLE
Discord Channel Improvements

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1,0 +1,136 @@
+# Discord Channel
+
+The Discord channel handler connects an agent to a Discord bot. It handles message sending, receiving, history, reactions, slash commands, and attachments — everything needed for the agent to operate in guild channels and DMs.
+
+## Configuration
+
+The channel is configured per-agent at `~/.cireilclaw/agents/<slug>/config/channels/discord.toml`.
+
+### Minimal
+
+```toml
+token = "MTxxxxxxxxxxxxxxxxxxxxxxxx.xxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ownerId = "123456789012345678"
+```
+
+### Full
+
+```toml
+token = "MTxxxxxxxxxxxxxxxxxxxxxxxx.xxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ownerId = "123456789012345678"
+
+# REST request timeout in ms (default 60000)
+timeout = 30000
+
+# Restrict which users can send messages the agent sees
+access = { mode = "allowlist", users = ["123456789012345678"] }
+
+# Restrict DM access
+directMessages = { mode = "owner", users = [] }
+```
+
+### Fields
+
+| Field            | Required | Default    | Description                                             |
+| ---------------- | -------- | ---------- | ------------------------------------------------------- |
+| `token`          | Yes      | —          | Bot token from the Discord Developer Portal             |
+| `ownerId`        | Yes      | —          | Discord user ID of the bot operator (numeric snowflake) |
+| `timeout`        | No       | `60000`    | REST request timeout in milliseconds                    |
+| `access`         | No       | `disabled` | Access restriction for guild channels (see below)       |
+| `directMessages` | No       | `"owner"`  | DM access mode (see below)                              |
+
+### Access Modes
+
+Controls who can interact with the agent in guild channels.
+
+| Mode        | Behavior                                           |
+| ----------- | -------------------------------------------------- |
+| `disabled`  | Anyone can interact (default)                      |
+| `allowlist` | Only users in `users` can interact, plus the owner |
+| `denylist`  | Everyone can interact except users in `users`      |
+
+The `ownerId` user always bypasses access control regardless of mode.
+
+### Direct Message Modes
+
+Controls who can DM the agent.
+
+| Mode        | Behavior                                     |
+| ----------- | -------------------------------------------- |
+| `owner`     | Only the owner can DM (default)              |
+| `public`    | Anyone can DM                                |
+| `allowlist` | Only users in `users` can DM, plus the owner |
+| `denylist`  | Everyone can DM except users in `users`      |
+
+## Message Processing
+
+Messages are processed when the agent is mentioned, replied to, or sent via DM (depending on DM mode). The bot reads the last 50 messages for context on each turn, crawling reply chains for full thread context.
+
+The bot responds in the same channel. Long responses are automatically split at sensible boundaries (code fences, line breaks) to stay under Discord's 2000-character limit.
+
+### History
+
+Messages maintain session history across turns. If a message is deleted from Discord (by anyone with permission), the bot removes it from its internal history on the next turn. This keeps the agent from referencing deleted content.
+
+## Slash Commands
+
+All slash commands are restricted to the configured `ownerId`.
+
+| Command        | Description                                |
+| -------------- | ------------------------------------------ |
+| `/clear`       | Reset conversation history for the channel |
+| `/close`       | Close an open file in the current session  |
+| `/invite`      | Get an invite link for the bot             |
+| `/model`       | Switch the provider/model for this session |
+| `/repair`      | Repair corrupted Discord media attachments |
+| `/stop`        | Gracefully stop the current generation     |
+| `/summarize`   | Summarize the conversation history         |
+| `/unsummarize` | Remove the most recent summary             |
+
+## Owner Reactions
+
+The owner (user matching `ownerId`) can react to the bot's messages to trigger actions. These work in any channel the bot can see.
+
+| Reaction | Behavior                                                                                                                          |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| ✨       | **Delete error messages only.** If the bot's message is an engine or Discord error, delete it. No reroll.                         |
+| ❌       | **Delete single message.** Delete the message from Discord and remove it from session history. Does not touch other messages.     |
+| 🔄       | **Delete + reroll.** Delete the message from Discord, remove it and everything after it from history, then regenerate a response to the preceding user message. |
+
+The ✨ reaction only acts on error messages (starting with "⚠️ Engine error", ":warning: Engine error", "⚠️ Discord error", or ":warning: Discord error"). ❌ and 🔄 work on any bot message.
+
+❌ removes only the single reacted-to message from history — conversation entries before and after are left intact.
+
+🔄 removes the reacted-to message plus everything after it (rewinding to that point), then generates a new response. If no user message remains after the splice (e.g., reacting to the very first message in a session), the deletion happens but no reroll occurs.
+
+Reactions from non-owner users are silently ignored. Reactions on non-bot messages are ignored.
+
+## Required Intents
+
+The bot registers the following gateway intents:
+
+- `GUILD_MESSAGES`
+- `DIRECT_MESSAGES`
+- `MESSAGE_CONTENT`
+- `GUILD_MESSAGE_REACTIONS`
+- `DIRECT_MESSAGE_REACTIONS`
+
+These must be enabled in the Discord Developer Portal under the bot's settings.
+
+## Supported Content
+
+### Images
+
+The bot accepts common image formats (PNG, JPEG, GIF, WebP). Images are converted to WebP before being sent to the model. Stickers are also fetched and converted to WebP (LOTTIE format stickers are skipped as they cannot be rasterized).
+
+### Videos
+
+The bot accepts videos from providers that support vision (configured with `supportsVideo` in the engine config). Videos larger than the configured cap are skipped with a warning.
+
+### Attachments
+
+File and text attachments are sent with metadata so the model knows what's available, but only images and videos are fetched and sent to the model — plain file contents are not ingested.
+
+## Message Splitting
+
+Messages exceeding Discord's 2000-character limit are split into multiple messages. The splitter is fence-aware: if a split falls inside a code block, the chunk is closed with ``` and re-opened with the same fence on the next chunk.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -89,21 +89,22 @@ All slash commands are restricted to the configured `ownerId`.
 
 ## Owner Reactions
 
-The owner (user matching `ownerId`) can react to the bot's messages to trigger actions. These work in any channel the bot can see.
+The owner (user matching `ownerId`) can react to the bot's **error messages** with ✨ to dismiss them. The ✨ reaction only acts on messages starting with "⚠️ Engine error", ":warning: Engine error", "⚠️ Discord error", or ":warning: Discord error".
 
-| Reaction | Behavior                                                                                                                          |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| ✨       | **Delete error messages only.** If the bot's message is an engine or Discord error, delete it. No reroll.                         |
-| ❌       | **Delete single message.** Delete the message from Discord and remove it from session history. Does not touch other messages.     |
-| 🔄       | **Delete + reroll.** Delete the message from Discord, remove it and everything after it from history, then regenerate a response to the preceding user message. |
+Reactions from non-owner users or on non-bot messages are silently ignored.
 
-The ✨ reaction only acts on error messages (starting with "⚠️ Engine error", ":warning: Engine error", "⚠️ Discord error", or ":warning: Discord error"). ❌ and 🔄 work on any bot message.
+## Owner Message Commands
 
-❌ removes only the single reacted-to message from history — conversation entries before and after are left intact.
+The owner can right-click (desktop) or long-press (mobile) any bot message and select an action from the **Apps** menu. These commands are only visible to the owner and produce ephemeral responses (visible only to you).
 
-🔄 removes the reacted-to message plus everything after it (rewinding to that point), then generates a new response. If no user message remains after the splice (e.g., reacting to the very first message in a session), the deletion happens but no reroll occurs.
+| Command             | Behavior                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Delete Message**  | Delete the message from Discord and remove it from session history. Does not touch other messages.                                         |
+| **Reroll Response** | Delete the message from Discord, remove it and everything after it from history, then regenerate a response to the preceding user message. |
 
-Reactions from non-owner users are silently ignored. Reactions on non-bot messages are ignored.
+**Delete Message** removes only the single targeted message from history — conversation entries before and after are left intact.
+
+**Reroll Response** removes the targeted message plus everything after it (rewinding to that point), then generates a new response. If no user message remains after the splice (e.g., targeting the very first message in a session), the deletion happens but no reroll occurs.
 
 ## Required Intents
 

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -6,7 +6,6 @@ import path from "node:path";
 
 import type {
   AnyInteractionGateway,
-  AnyTextableChannel,
   Client as OceanicClient,
   CommandInteraction,
   Message as DiscordMessage,
@@ -18,6 +17,7 @@ import type {
   AutocompleteInteraction,
 } from "oceanic.js";
 import {
+  ApplicationCommandTypes,
   ChannelTypes,
   InteractionTypes,
   MessageFlags,
@@ -27,10 +27,12 @@ import {
 
 import * as clearCommand from "#channels/discord/clear-command.js";
 import * as closeCommand from "#channels/discord/close-command.js";
+import * as deleteCommand from "#channels/discord/delete-command.js";
 import type { HandlerCtx } from "#channels/discord/handler-ctx.js";
 import * as inviteCommand from "#channels/discord/invite-command.js";
 import * as modelCommand from "#channels/discord/model-command.js";
 import * as repairCommand from "#channels/discord/repair-command.js";
+import * as rerollCommand from "#channels/discord/reroll-command.js";
 import { runDiscordRestWithRetries } from "#channels/discord/rest-retry.js";
 import * as stopCommand from "#channels/discord/stop-command.js";
 import * as summarizeCommand from "#channels/discord/summarize-command.js";
@@ -63,26 +65,31 @@ const { Client, Intents } = createRequire(import.meta.url)(
 const CHUNK_LIMIT = 1800;
 const TYPING_INTERVAL_MS = 5000;
 
-// All registered slash commands. Add new command modules here — the hash
-// check on startup will detect changes and re-register with Discord's API.
-const SLASH_COMMANDS = [
+// All registered application commands (slash + message). Add new command
+// modules here — the hash check on startup will detect changes and
+// re-register with Discord's API.
+const COMMANDS = [
   clearCommand.definition,
   closeCommand.definition,
+  deleteCommand.definition,
   inviteCommand.definition,
   modelCommand.definition,
   repairCommand.definition,
+  rerollCommand.definition,
   stopCommand.definition,
   summarizeCommand.definition,
   unsummarizeCommand.definition,
 ];
 
-type SlashHandler = (interaction: CommandInteraction, ctx: HandlerCtx) => Promise<void>;
-const SLASH_HANDLERS = new Map<string, SlashHandler>([
+type CommandHandler = (interaction: CommandInteraction, ctx: HandlerCtx) => Promise<void>;
+const HANDLERS = new Map<string, CommandHandler>([
   ["clear", clearCommand.handle],
   ["close", closeCommand.handleCommand],
+  ["Delete Message", deleteCommand.handle],
   ["invite", inviteCommand.handle],
   ["model", modelCommand.handleCommand],
   ["repair", repairCommand.handle],
+  ["Reroll Response", rerollCommand.handle],
   ["stop", stopCommand.handle],
   ["summarize", summarizeCommand.handleCommand],
   ["unsummarize", unsummarizeCommand.handleCommand],
@@ -96,8 +103,8 @@ const AUTOCOMPLETE_HANDLERS = new Map<string, AutocompleteHandler>([
   ["model", modelCommand.handleAutocomplete],
 ]);
 
-// Persisted hash of SLASH_COMMANDS to avoid re-registering on every startup.
-const COMMANDS_HASH = createHash("sha256").update(JSON.stringify(SLASH_COMMANDS)).digest("hex");
+// Persisted hash of COMMANDS to avoid re-registering on every startup.
+const COMMANDS_HASH = createHash("sha256").update(JSON.stringify(COMMANDS)).digest("hex");
 
 function commandsHashFile(agentSlug: string): string {
   return path.join(agentRoot(agentSlug), "discord-commands.hash");
@@ -912,104 +919,23 @@ async function handleMessageReactionAdd(
       return;
     }
 
-    if (reaction.emoji.name === "✨") {
-      if (
-        realMsg.content.startsWith("⚠️ Engine error") ||
-        realMsg.content.startsWith(":warning: Engine error") ||
-        realMsg.content.startsWith("⚠️ Discord error") ||
-        realMsg.content.startsWith(":warning: Discord error")
-      ) {
-        await realMsg.delete("No longer necessary");
-      }
+    if (reaction.emoji.name !== "✨") {
       return;
     }
 
-    // ❌ delete-only vs 🔄 delete + reroll: shared history cleanup
-    if (reaction.emoji.name === "❌" || reaction.emoji.name === "🔄") {
-      const isReroll = reaction.emoji.name === "🔄";
-
-      const agent = ctx.owner.agents.get(ctx.agentSlug);
-      if (agent === undefined) {
-        return;
-      }
-
-      const sessionId =
-        msg.guildID === undefined
-          ? `discord:${msg.channelID}`
-          : `discord:${msg.channelID}|${msg.guildID}`;
-
-      const session = agent.sessions.get(sessionId);
-      if (session === undefined || !(session instanceof DiscordSession)) {
-        return;
-      }
-
-      if (session.busy) {
-        return;
-      }
-
-      const msgIndex = session.history.findIndex((entry) => entry.id === msg.id);
-      if (msgIndex === -1) {
-        return;
-      }
-
-      await realMsg.delete(isReroll ? "Reroll triggered by owner" : "Deleted by owner");
-
-      if (!isReroll) {
-        // ❌ — delete only: just remove this single message
-        session.history.splice(msgIndex, 1);
-        session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
-        saveSession(ctx.agentSlug, session);
-        return;
-      }
-
-      // 🔄 — delete + reroll: wipe this message and everything after, then regenerate
-      session.history.splice(msgIndex);
-      session.pendingToolMessages = [];
-      session.pendingVideos = [];
-
-      const lastUserMsg = session.history.findLast(
-        (entry) => entry.role === "user" && entry.id !== undefined,
-      );
-      session.lastMessageId = lastUserMsg?.id;
-
-      if (lastUserMsg === undefined) {
-        saveSession(ctx.agentSlug, session);
-        return;
-      }
-
-      session.stopRequested = false;
-
-      // Keep the channel alive while the turn runs
-      const channel = await runDiscordRestWithRetries(
-        "GET /channels/{id}",
-        async () => await ctx.client.rest.channels.get(msg.channelID),
-      );
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const textChannel = channel as AnyTextableChannel;
-      await textChannel.sendTyping();
-
-      const typingInterval = setInterval(() => {
-        // oxlint-disable-next-line promise/prefer-await-to-then
-        textChannel.sendTyping().catch(() => {
-          // Intentionally ignored
-        });
-      }, TYPING_INTERVAL_MS);
-
-      session.busy = true;
-      try {
-        await agent.runTurn(session);
-      } finally {
-        clearInterval(typingInterval);
-        session.busy = false;
-        saveSession(ctx.agentSlug, session);
-      }
+    if (
+      realMsg.content.startsWith("\u26A0\uFE0F Engine error") ||
+      realMsg.content.startsWith(":warning: Engine error") ||
+      realMsg.content.startsWith("\u26A0\uFE0F Discord error") ||
+      realMsg.content.startsWith(":warning: Discord error")
+    ) {
+      await realMsg.delete("No longer necessary");
     }
   } catch (error: unknown) {
     warning(
       "Failed during reaction add handler:",
       error instanceof Error ? error.message : String(error),
     );
-
     if (error instanceof Error) {
       warning(error);
     }
@@ -1137,11 +1063,16 @@ async function handleInteractionCreate(
   }
 
   if (interaction.type === InteractionTypes.APPLICATION_COMMAND) {
-    const handler = SLASH_HANDLERS.get(interaction.data.name);
+    // Message commands (right-click → Apps) always respond ephemerally.
+    // Slash commands use the SILENT_COMMANDS set.
+    const isEphemeral =
+      interaction.data.type === ApplicationCommandTypes.MESSAGE ||
+      SILENT_COMMANDS.has(interaction.data.name);
+    const deferFlags = isEphemeral ? MessageFlags.EPHEMERAL : 0;
+
+    const handler = HANDLERS.get(interaction.data.name);
     if (handler !== undefined) {
-      await interaction.defer(
-        SILENT_COMMANDS.has(interaction.data.name) ? MessageFlags.EPHEMERAL : 0,
-      );
+      await interaction.defer(deferFlags);
 
       await handler(interaction, ctx);
     }
@@ -1336,9 +1267,9 @@ async function startDiscord(owner: Harness, agentSlug: string): Promise<OceanicC
     const storedHash = readCommandsHash(agentSlug);
     if (storedHash !== commandsFingerprint) {
       try {
-        await client.rest.applications.bulkEditGlobalCommands(appId, SLASH_COMMANDS);
+        await client.rest.applications.bulkEditGlobalCommands(appId, COMMANDS);
         writeCommandsHash(agentSlug, commandsFingerprint);
-        info("Registered Discord slash commands");
+        info("Registered Discord application commands");
       } catch (error) {
         warning(
           "Failed to register slash commands:",

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -954,24 +954,24 @@ async function handleMessageReactionAdd(
 
       await realMsg.delete(isReroll ? "Reroll triggered by owner" : "Deleted by owner");
 
-      // Wipe the message and everything that followed so history is consistent
+      if (!isReroll) {
+        // ❌ — delete only: just remove this single message
+        session.history.splice(msgIndex, 1);
+        session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+        saveSession(ctx.agentSlug, session);
+        return;
+      }
+
+      // 🔄 — delete + reroll: wipe this message and everything after, then regenerate
       session.history.splice(msgIndex);
       session.pendingToolMessages = [];
       session.pendingVideos = [];
 
-      // Point lastMessageId at the preceding user message so future turns work
       const lastUserMsg = session.history.findLast(
         (entry) => entry.role === "user" && entry.id !== undefined,
       );
       session.lastMessageId = lastUserMsg?.id;
 
-      if (!isReroll) {
-        // ❌ — delete only
-        saveSession(ctx.agentSlug, session);
-        return;
-      }
-
-      // 🔄 — reroll: regenerate response to the last user message
       if (lastUserMsg === undefined) {
         saveSession(ctx.agentSlug, session);
         return;

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import type {
   AnyInteractionGateway,
+  AnyTextableChannel,
   Client as OceanicClient,
   CommandInteraction,
   Message as DiscordMessage,
@@ -911,17 +912,97 @@ async function handleMessageReactionAdd(
       return;
     }
 
-    if (reaction.emoji.name !== "✨") {
+    if (reaction.emoji.name === "✨") {
+      if (
+        realMsg.content.startsWith("⚠️ Engine error") ||
+        realMsg.content.startsWith(":warning: Engine error") ||
+        realMsg.content.startsWith("⚠️ Discord error") ||
+        realMsg.content.startsWith(":warning: Discord error")
+      ) {
+        await realMsg.delete("No longer necessary");
+      }
       return;
     }
 
-    if (
-      realMsg.content.startsWith("⚠️ Engine error") ||
-      realMsg.content.startsWith(":warning: Engine error") ||
-      realMsg.content.startsWith("⚠️ Discord error") ||
-      realMsg.content.startsWith(":warning: Discord error")
-    ) {
-      await realMsg.delete("No longer necessary");
+    // ❌ delete-only vs 🔄 delete + reroll: shared history cleanup
+    if (reaction.emoji.name === "❌" || reaction.emoji.name === "🔄") {
+      const isReroll = reaction.emoji.name === "🔄";
+
+      const agent = ctx.owner.agents.get(ctx.agentSlug);
+      if (agent === undefined) {
+        return;
+      }
+
+      const sessionId =
+        msg.guildID === undefined
+          ? `discord:${msg.channelID}`
+          : `discord:${msg.channelID}|${msg.guildID}`;
+
+      const session = agent.sessions.get(sessionId);
+      if (session === undefined || !(session instanceof DiscordSession)) {
+        return;
+      }
+
+      if (session.busy) {
+        return;
+      }
+
+      const msgIndex = session.history.findIndex((entry) => entry.id === msg.id);
+      if (msgIndex === -1) {
+        return;
+      }
+
+      await realMsg.delete(isReroll ? "Reroll triggered by owner" : "Deleted by owner");
+
+      // Wipe the message and everything that followed so history is consistent
+      session.history.splice(msgIndex);
+      session.pendingToolMessages = [];
+      session.pendingVideos = [];
+
+      // Point lastMessageId at the preceding user message so future turns work
+      const lastUserMsg = session.history.findLast(
+        (entry) => entry.role === "user" && entry.id !== undefined,
+      );
+      session.lastMessageId = lastUserMsg?.id;
+
+      if (!isReroll) {
+        // ❌ — delete only
+        saveSession(ctx.agentSlug, session);
+        return;
+      }
+
+      // 🔄 — reroll: regenerate response to the last user message
+      if (lastUserMsg === undefined) {
+        saveSession(ctx.agentSlug, session);
+        return;
+      }
+
+      session.stopRequested = false;
+
+      // Keep the channel alive while the turn runs
+      const channel = await runDiscordRestWithRetries(
+        "GET /channels/{id}",
+        async () => await ctx.client.rest.channels.get(msg.channelID),
+      );
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      const textChannel = channel as AnyTextableChannel;
+      await textChannel.sendTyping();
+
+      const typingInterval = setInterval(() => {
+        // oxlint-disable-next-line promise/prefer-await-to-then
+        textChannel.sendTyping().catch(() => {
+          // Intentionally ignored
+        });
+      }, TYPING_INTERVAL_MS);
+
+      session.busy = true;
+      try {
+        await agent.runTurn(session);
+      } finally {
+        clearInterval(typingInterval);
+        session.busy = false;
+        saveSession(ctx.agentSlug, session);
+      }
     }
   } catch (error: unknown) {
     warning(

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -86,6 +86,9 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         return;
       }
 
+      // Delete the Discord message first — don't mutate session unless this succeeds
+      await targetMsg.delete("Deleted by owner");
+
       // Adjust cursor if it points past the removed entry
       if (session.historyCursor > msgIndex) {
         session.historyCursor--;
@@ -94,7 +97,6 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       session.history.splice(msgIndex, 1);
       session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
       saveSession(ctx.agentSlug, session);
-      await targetMsg.delete("Deleted by owner");
     } finally {
       session.busy = false;
       saveSession(ctx.agentSlug, session);

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -1,0 +1,90 @@
+import type {
+  CommandInteraction,
+  CreateApplicationCommandOptions,
+  Message as DiscordMessage,
+} from "oceanic.js";
+import { ApplicationCommandTypes, MessageFlags } from "oceanic.js";
+
+import type { HandlerCtx } from "#channels/discord/handler-ctx.js";
+import { saveSession } from "#db/sessions.js";
+import { DiscordSession } from "#harness/session.js";
+import { sanitizeError } from "#util/paths.js";
+
+const definition: CreateApplicationCommandOptions = {
+  name: "Delete Message",
+  type: ApplicationCommandTypes.MESSAGE,
+};
+
+async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise<void> {
+  try {
+    const { target } = interaction.data;
+    if (!target || !("author" in target)) {
+      await interaction.createFollowup({
+        content: "Could not resolve the target message.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    // Narrow from User | Message to Message — message commands always target
+    // a message, and the "author" in-check above excludes the User variant.
+    const targetMsg = target as DiscordMessage;
+
+    if (targetMsg.author.id !== ctx.client.application.id) {
+      await interaction.createFollowup({
+        content: "Can only delete messages from this bot.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    const sessionId =
+      // undefined semantics are better than null semantics
+      (interaction.guildID ?? undefined) === undefined
+        ? `discord:${interaction.channelID}`
+        : `discord:${interaction.channelID}|${interaction.guildID}`;
+
+    if (!ctx.owner.agents.has(ctx.agentSlug)) {
+      await interaction.createFollowup({
+        content: "Failed to find the agent session.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+    const agent = ctx.owner.agents.get(ctx.agentSlug);
+
+    if (agent === undefined) {
+      throw new Error("Agent is (for some reason) undefined. Should be impossible if we're here.");
+    }
+
+    const session = agent.sessions.get(sessionId);
+    if (session === undefined || !(session instanceof DiscordSession)) {
+      await interaction.createFollowup({
+        content: "No active session in this channel.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    await targetMsg.delete("Deleted by owner");
+
+    const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+    if (msgIndex !== -1) {
+      session.history.splice(msgIndex, 1);
+      session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+      saveSession(ctx.agentSlug, session);
+    }
+
+    await interaction.createFollowup({
+      content: "Message deleted.",
+      flags: MessageFlags.EPHEMERAL,
+    });
+  } catch (error) {
+    await interaction.createFollowup({
+      content: `Delete failed: ${sanitizeError(error, ctx.agentSlug)}`,
+      flags: MessageFlags.EPHEMERAL,
+    });
+  }
+}
+
+export { definition, handle };

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -66,6 +66,14 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       return;
     }
 
+    if (session.busy) {
+      await interaction.createFollowup({
+        content: "A generation is in progress. Try again when it finishes.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
     await targetMsg.delete("Deleted by owner");
 
     const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -77,13 +77,24 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
     session.busy = true;
     saveSession(ctx.agentSlug, session);
     try {
-      await targetMsg.delete("Deleted by owner");
-
       const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
-      if (msgIndex !== -1) {
-        session.history.splice(msgIndex, 1);
-        session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+      if (msgIndex === -1) {
+        await interaction.createFollowup({
+          content: "Cannot delete a message not found in session history.",
+          flags: MessageFlags.EPHEMERAL,
+        });
+        return;
       }
+
+      // Adjust cursor if it points past the removed entry
+      if (session.historyCursor > msgIndex) {
+        session.historyCursor--;
+      }
+
+      session.history.splice(msgIndex, 1);
+      session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+      saveSession(ctx.agentSlug, session);
+      await targetMsg.delete("Deleted by owner");
     } finally {
       session.busy = false;
       saveSession(ctx.agentSlug, session);

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -74,12 +74,18 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       return;
     }
 
-    await targetMsg.delete("Deleted by owner");
+    session.busy = true;
+    saveSession(ctx.agentSlug, session);
+    try {
+      await targetMsg.delete("Deleted by owner");
 
-    const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
-    if (msgIndex !== -1) {
-      session.history.splice(msgIndex, 1);
-      session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+      const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+      if (msgIndex !== -1) {
+        session.history.splice(msgIndex, 1);
+        session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+      }
+    } finally {
+      session.busy = false;
       saveSession(ctx.agentSlug, session);
     }
 

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -1,0 +1,145 @@
+import type {
+  AnyTextableChannel,
+  CommandInteraction,
+  CreateApplicationCommandOptions,
+  Message as DiscordMessage,
+} from "oceanic.js";
+import { ApplicationCommandTypes, MessageFlags } from "oceanic.js";
+
+import type { HandlerCtx } from "#channels/discord/handler-ctx.js";
+import { runDiscordRestWithRetries } from "#channels/discord/rest-retry.js";
+import { saveSession } from "#db/sessions.js";
+import { DiscordSession } from "#harness/session.js";
+import { sanitizeError } from "#util/paths.js";
+
+const TYPING_INTERVAL_MS = 5000;
+
+const definition: CreateApplicationCommandOptions = {
+  name: "Reroll Response",
+  type: ApplicationCommandTypes.MESSAGE,
+};
+
+async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise<void> {
+  try {
+    const { target } = interaction.data;
+    if (!target || !("author" in target)) {
+      await interaction.createFollowup({
+        content: "Could not resolve the target message.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    // Narrow from User | Message to Message — message commands always target
+    // a message, and the "author" in-check above excludes the User variant.
+    const targetMsg = target as DiscordMessage;
+
+    if (targetMsg.author.id !== ctx.client.application.id) {
+      await interaction.createFollowup({
+        content: "Can only reroll responses from this bot.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    const sessionId =
+      // undefined semantics are better than null semantics
+      (interaction.guildID ?? undefined) === undefined
+        ? `discord:${interaction.channelID}`
+        : `discord:${interaction.channelID}|${interaction.guildID}`;
+
+    if (!ctx.owner.agents.has(ctx.agentSlug)) {
+      await interaction.createFollowup({
+        content: "Failed to find the agent session.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+    const agent = ctx.owner.agents.get(ctx.agentSlug);
+
+    if (agent === undefined) {
+      throw new Error("Agent is (for some reason) undefined. Should be impossible if we're here.");
+    }
+
+    const session = agent.sessions.get(sessionId);
+    if (session === undefined || !(session instanceof DiscordSession)) {
+      await interaction.createFollowup({
+        content: "No active session in this channel.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    if (session.busy) {
+      await interaction.createFollowup({
+        content: "A generation is already running. Wait for it to finish.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+    if (msgIndex === -1) {
+      await interaction.createFollowup({
+        content: "Could not find this message in session history.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    await targetMsg.delete("Reroll triggered by owner");
+
+    // Wipe this message and everything after from history
+    session.history.splice(msgIndex);
+    session.pendingToolMessages = [];
+    session.pendingVideos = [];
+
+    const lastUserMsg = session.history.findLast(
+      (entry) => entry.role === "user" && entry.id !== undefined,
+    );
+    session.lastMessageId = lastUserMsg?.id;
+
+    if (lastUserMsg === undefined) {
+      saveSession(ctx.agentSlug, session);
+      await interaction.createFollowup({
+        content: "No user message to reroll from. Message deleted.",
+        flags: MessageFlags.EPHEMERAL,
+      });
+      return;
+    }
+
+    session.stopRequested = false;
+
+    // Keep the channel alive while the turn runs
+    const channel = await runDiscordRestWithRetries(
+      "GET /channels/{id}",
+      async () => await ctx.client.rest.channels.get(interaction.channelID),
+    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const textChannel = channel as AnyTextableChannel;
+    await textChannel.sendTyping();
+
+    const typingInterval = setInterval(() => {
+      // oxlint-disable-next-line promise/prefer-await-to-then
+      textChannel.sendTyping().catch(() => {
+        // Intentionally ignored
+      });
+    }, TYPING_INTERVAL_MS);
+
+    session.busy = true;
+    try {
+      await agent.runTurn(session);
+    } finally {
+      clearInterval(typingInterval);
+      session.busy = false;
+      saveSession(ctx.agentSlug, session);
+    }
+  } catch (error) {
+    await interaction.createFollowup({
+      content: `Reroll failed: ${sanitizeError(error, ctx.agentSlug)}`,
+      flags: MessageFlags.EPHEMERAL,
+    });
+  }
+}
+
+export { definition, handle };

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -78,59 +78,65 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       return;
     }
 
-    const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
-    if (msgIndex === -1) {
-      await interaction.createFollowup({
-        content: "Could not find this message in session history.",
-        flags: MessageFlags.EPHEMERAL,
-      });
-      return;
-    }
-
-    await targetMsg.delete("Reroll triggered by owner");
-
-    // Wipe this message and everything after from history
-    session.history.splice(msgIndex);
-    session.pendingToolMessages = [];
-    session.pendingVideos = [];
-
-    const lastUserMsg = session.history.findLast(
-      (entry) => entry.role === "user" && entry.id !== undefined,
-    );
-    session.lastMessageId = lastUserMsg?.id;
-
-    if (lastUserMsg === undefined) {
-      saveSession(ctx.agentSlug, session);
-      await interaction.createFollowup({
-        content: "No user message to reroll from. Message deleted.",
-        flags: MessageFlags.EPHEMERAL,
-      });
-      return;
-    }
-
-    session.stopRequested = false;
-
-    // Keep the channel alive while the turn runs
-    const channel = await runDiscordRestWithRetries(
-      "GET /channels/{id}",
-      async () => await ctx.client.rest.channels.get(interaction.channelID),
-    );
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    const textChannel = channel as AnyTextableChannel;
-    await textChannel.sendTyping();
-
-    const typingInterval = setInterval(() => {
-      // oxlint-disable-next-line promise/prefer-await-to-then
-      textChannel.sendTyping().catch(() => {
-        // Intentionally ignored
-      });
-    }, TYPING_INTERVAL_MS);
-
     session.busy = true;
+    let typingInterval: ReturnType<typeof setInterval> | undefined = undefined;
     try {
+      const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+      if (msgIndex === -1) {
+        await interaction.createFollowup({
+          content: "Could not find this message in session history.",
+          flags: MessageFlags.EPHEMERAL,
+        });
+        return;
+      }
+
+      await targetMsg.delete("Reroll triggered by owner");
+
+      // Wipe this message and everything after from history
+      session.history.splice(msgIndex);
+      session.pendingToolMessages = [];
+      session.pendingVideos = [];
+
+      const lastUserMsg = session.history.findLast(
+        (entry) => entry.role === "user" && entry.id !== undefined,
+      );
+      session.lastMessageId = lastUserMsg?.id;
+
+      if (lastUserMsg === undefined) {
+        saveSession(ctx.agentSlug, session);
+        await interaction.createFollowup({
+          content: "No user message to reroll from. Message deleted.",
+          flags: MessageFlags.EPHEMERAL,
+        });
+        return;
+      }
+
+      session.stopRequested = false;
+
+      // Best-effort typing indicator — don't let failures abort the reroll
+      try {
+        const channel = await runDiscordRestWithRetries(
+          "GET /channels/{id}",
+          async () => await ctx.client.rest.channels.get(interaction.channelID),
+        );
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+        const textChannel = channel as AnyTextableChannel;
+        await textChannel.sendTyping();
+        typingInterval = setInterval(() => {
+          // oxlint-disable-next-line promise/prefer-await-to-then
+          textChannel.sendTyping().catch(() => {
+            // Intentionally ignored
+          });
+        }, TYPING_INTERVAL_MS);
+      } catch {
+        // Typing setup failed — proceed without it
+      }
+
       await agent.runTurn(session);
     } finally {
-      clearInterval(typingInterval);
+      if (typingInterval !== undefined) {
+        clearInterval(typingInterval);
+      }
       session.busy = false;
       saveSession(ctx.agentSlug, session);
     }

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -96,6 +96,10 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
 
       // Wipe this message and everything after from history
       session.history.splice(msgIndex);
+      // Clamp cursor so it doesn't point past the new end of history
+      if (session.historyCursor >= session.history.length) {
+        session.historyCursor = Math.max(0, session.history.length - 1);
+      }
       session.pendingToolMessages = [];
       session.pendingVideos = [];
 

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -132,7 +132,25 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         // Typing setup failed — proceed without it
       }
 
-      await agent.runTurn(session);
+      // Save history length before the turn so we can roll back if it fails.
+      // Unlike the normal Discord turn path (discord.ts), the reroll has
+      // already deleted the original bot message from Discord and spliced
+      // history — we cannot restore the message, but we can restore session
+      // state back to the user message the reroll was triggered from.
+      const historyLengthBeforeTurn = session.history.length;
+
+      try {
+        await agent.runTurn(session);
+      } catch (error) {
+        // Roll back any history entries the failed turn may have pushed, clear
+        // pending tool/media state, and re-throw so the outer catch sends the
+        // error response to the user.
+        session.history.length = historyLengthBeforeTurn;
+        session.pendingToolMessages.length = 0;
+        session.pendingVideos.length = 0;
+        session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+        throw error;
+      }
     } finally {
       if (typingInterval !== undefined) {
         clearInterval(typingInterval);

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -20,6 +20,8 @@ const definition: CreateApplicationCommandOptions = {
 };
 
 async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise<void> {
+  // Track whether a rollback occurred so the error message can report it.
+  let didRollback = false;
   try {
     const { target } = interaction.data;
     if (!target || !("author" in target)) {
@@ -149,6 +151,7 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         session.pendingToolMessages.length = 0;
         session.pendingVideos.length = 0;
         session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
+        didRollback = true;
         throw error;
       }
     } finally {
@@ -159,8 +162,14 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       saveSession(ctx.agentSlug, session);
     }
   } catch (error) {
+    // didRollback is set inside a nested catch before re-throw; TS can't
+    // track assignments through that control-flow path into this outer catch.
+    // oxlint-disable-next-line typescript/no-unnecessary-condition
+    const rollbackNote = didRollback
+      ? " Session state has been rolled back to before the reroll target."
+      : "";
     await interaction.createFollowup({
-      content: `Reroll failed: ${sanitizeError(error, ctx.agentSlug)}`,
+      content: `Reroll failed: ${sanitizeError(error, ctx.agentSlug)}${rollbackNote}`,
       flags: MessageFlags.EPHEMERAL,
     });
   }

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -149,6 +149,7 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         // error response to the user.
         session.history.length = historyLengthBeforeTurn;
         session.pendingToolMessages.length = 0;
+        session.pendingImages.length = 0;
         session.pendingVideos.length = 0;
         session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
         didRollback = true;

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -101,6 +101,7 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         session.historyCursor = Math.max(0, session.history.length - 1);
       }
       session.pendingToolMessages = [];
+      session.pendingImages = [];
       session.pendingVideos = [];
 
       const lastUserMsg = session.history.findLast(


### PR DESCRIPTION
Adds two new owner-only actions:
- "Delete Message" Message Command that deletes the agent message
- "Reroll Message" Message Command that deletes the agent message and regenerates it.

Note that this does *not* affect edits that happened during the deleted turn; those still happened. Take care in using these reactions.

<!-- initial implementation was using emojis, but after further consideration that's being changed -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
All prior observations remain accurate. After reviewing the changed files I have three small updates and confirmations beyond the previous summary:

- Documentation added
  - docs/channels/discord.md added (137 LOC) with full handler docs: per-agent discord.toml examples/fields, access and DM modes, message processing/history, owner-only slash + message commands, owner reactions for engine/discord error dismissal, required intents, supported content types and conversion rules, attachment handling, and fence-aware 2000-char message splitting.

- Concurrency / recovery and state-persistence tweaks
  - Delete command: validates the target exists in session.history before calling the Discord delete API, sets session.busy and persists immediately (saveSession) to claim the session lock before performing the destructive API call, waits for the Discord deletion to succeed before mutating session.history, adjusts historyCursor when splicing, recomputes lastMessageId, persists again in finally, and returns ephemeral follow-ups for validation/errors.
  - Reroll command: when reroll fails, the rollback handler now clears pendingImages in addition to pendingToolMessages/pendingVideos (prevents transient image state leaking into the next turn). Reroll also persists session state after acquiring/releasing the busy lock, uses a best-effort typing indicator with a cleared interval in finally, records historyLengthBeforeTurn so it can truncate history on failure and recompute lastMessageId, and handles the edge case where the target was the first message (deletes but does not re-run the agent).

- Command registration & interaction handling confirmations
  - Commands refactored to a unified COMMANDS array and HANDLERS map; a COMMANDS_HASH (sha256 of COMMANDS) is computed and persisted per-agent via discord-commands.hash under agentRoot(agentSlug) to avoid unnecessary re-registration on startup. The code reads/writes this file synchronously via node:fs (readFileSync/writeFileSync).
  - Message-type application commands are deferred ephemerally by default; SILENT_COMMANDS still govern slash command follow-up behavior.
  - HANDLERS map includes both canonical internal names and user-visible display names (e.g., "Delete Message", "Reroll Response") for lookup.
  - Both new message-command handlers validate interaction.data.target is a message, check the target's author equals the bot application id, verify agent and DiscordSession existence, and reject if session.busy.

Security-critical review (per requested subsystems)
- Path Isolation/Verification: The new per-agent persistence uses agentRoot(agentSlug)/discord-commands.hash via readFileSync/writeFileSync. This follows existing per-agent persisted-state patterns and does not introduce broader filesystem access or path-escaping beyond agentRoot usage from util/paths.
- Sandbox: No changes to sandboxing or execution isolation.
- Parsing and Validation: Interaction target validation, author checks, session type checks, and explicit session.busy gating are present in both handlers. The handlers persist session state when claiming/releasing busy and avoid mutating session state until after successful Discord deletions where appropriate, reducing race/corruption risk.

Conclusion: The PR introduces owner-only Discord message commands with careful session locking and rollback behavior, a documentation page, and command-registration refactors. The added persistence of COMMANDS_HASH and the new delete/reroll behavior improve correctness; I did not find changes that introduce new risks in the flagged subsystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->