### PR TITLE
feat: @cireilclaw/plugin-github — GitHub App integration plugin

### DIFF
--- a/config/plugins/github.toml.example
+++ b/config/plugins/github.toml.example
@@ -1,0 +1,14 @@
+# GitHub plugin configuration
+# Copy this file to ~/.cireilclaw/config/plugins/github.toml
+#
+# appId and installationId come from your GitHub App settings:
+#   https://github.com/settings/apps
+#
+# privateKey is the PEM-encoded private key generated when you create the app.
+# You can inline it directly or use a file path — TOML multi-line strings work.
+
+# appId = "123456"
+# installationId = "789012"
+# privateKey = """-----BEGIN RSA PRIVATE KEY-----
+# ...
+# -----END RSA PRIVATE KEY-----"""

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt --write .",
-    "format:check": "oxfmt --check ."
+    "format:check": "oxfmt --check .",
+    "publish:all": "pnpm publish -r --filter='@cireilclaw/*'"
   },
   "devDependencies": {
     "oxfmt": "^0.53.0",

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cireilclaw/plugin-brave-search",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "files": [
     "src",

--- a/packages/openweather/package.json
+++ b/packages/openweather/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cireilclaw/plugin-openweather",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "files": [
     "src",

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@cireilclaw/plugin-github",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "tsdown"
+  },
+  "devDependencies": {
+    "@cireilclaw/sdk": "workspace:*",
+    "tsdown": "^0.22.1",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "@cireilclaw/sdk": "^0.4.0"
+  }
+}

--- a/packages/plugin-github/src/api.ts
+++ b/packages/plugin-github/src/api.ts
@@ -8,6 +8,7 @@ async function gh(
   method: string,
   path: string,
   body?: unknown,
+  extraHeaders?: Record<string, string>,
 ): Promise<Response> {
   const token = await getInstallationToken(ctx);
   const url = new URL(path, "https://api.github.com");
@@ -16,6 +17,7 @@ async function gh(
     Accept: "application/vnd.github+json",
     Authorization: `Bearer ${token}`,
     "User-Agent": "cireilclaw-github-plugin",
+    ...extraHeaders,
   };
 
   const options: RequestInit = { headers, method };
@@ -50,4 +52,39 @@ async function ghParse<TData>(
   return (await response.json()) as TData;
 }
 
-export { gh, ghParse };
+function parseLinkNext(linkHeader: string | undefined): string | undefined {
+  if (linkHeader === undefined) {
+    return undefined;
+  }
+
+  for (const part of linkHeader.split(",")) {
+    const match = /<([^>]+)>;\s*rel="next"/u.exec(part.trim());
+    if (match?.[1] !== undefined) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+async function ghPaginate<TItem>(ctx: PluginToolContext, path: string): Promise<TItem[]> {
+  const results: TItem[] = [];
+  let nextUrl: string | undefined = path;
+
+  while (nextUrl !== undefined) {
+    const response = await gh(ctx, "GET", nextUrl);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new ToolError(`GitHub API error (${response.status}): ${text}`);
+    }
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const data = (await response.json()) as TItem[];
+    results.push(...data);
+
+    nextUrl = parseLinkNext(response.headers.get("link") ?? undefined);
+  }
+
+  return results;
+}
+
+export { gh, ghPaginate, ghParse, parseLinkNext };

--- a/packages/plugin-github/src/api.ts
+++ b/packages/plugin-github/src/api.ts
@@ -35,8 +35,9 @@ async function ghParse<TData>(
   method: string,
   path: string,
   body?: unknown,
+  extraHeaders?: Record<string, string>,
 ): Promise<TData> {
-  const response = await gh(ctx, method, path, body);
+  const response = await gh(ctx, method, path, body, extraHeaders);
 
   if (!response.ok) {
     const text = await response.text();

--- a/packages/plugin-github/src/api.ts
+++ b/packages/plugin-github/src/api.ts
@@ -51,4 +51,3 @@ async function ghParse<TData>(
 }
 
 export { gh, ghParse };
-

--- a/packages/plugin-github/src/api.ts
+++ b/packages/plugin-github/src/api.ts
@@ -1,0 +1,54 @@
+import type { PluginToolContext } from "@cireilclaw/sdk";
+import { ToolError } from "@cireilclaw/sdk";
+
+import { getInstallationToken } from "./auth.js";
+
+async function gh(
+  ctx: PluginToolContext,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<Response> {
+  const token = await getInstallationToken(ctx);
+  const url = new URL(path, "https://api.github.com");
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "cireilclaw-github-plugin",
+  };
+
+  const options: RequestInit = { headers, method };
+
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    options.body = JSON.stringify(body);
+  }
+
+  return ctx.net.fetch(url, options);
+}
+
+async function ghParse<TData>(
+  ctx: PluginToolContext,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<TData> {
+  const response = await gh(ctx, method, path, body);
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ToolError(`GitHub API error (${response.status}): ${text}`);
+  }
+
+  if (response.status === 204) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return {} as TData;
+  }
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return (await response.json()) as TData;
+}
+
+export { gh, ghParse };
+

--- a/packages/plugin-github/src/auth.ts
+++ b/packages/plugin-github/src/auth.ts
@@ -1,0 +1,69 @@
+import { createPrivateKey, sign } from "node:crypto";
+
+import type { PluginToolContext } from "@cireilclaw/sdk";
+import { ToolError } from "@cireilclaw/sdk";
+
+import { loadConfig } from "./config.js";
+
+interface TokenEntry {
+  token: string;
+  expiresAt: number;
+}
+
+let cachedToken: TokenEntry | undefined = undefined;
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+function generateJWT(appId: string, pem: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256" as const, typ: "JWT" };
+  const payload = {
+    exp: now + 600,
+    iat: now - 60,
+    iss: appId,
+  };
+
+  const signingInput = `${b64url(header)}.${b64url(payload)}`;
+  const key = createPrivateKey(pem);
+  const signature = sign(undefined, Buffer.from(signingInput), key);
+
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+export async function getInstallationToken(ctx: PluginToolContext): Promise<string> {
+  // Return cached token if still valid with 2-minute buffer
+  if (cachedToken !== undefined && cachedToken.expiresAt > Date.now() + 120_000) {
+    return cachedToken.token;
+  }
+
+  const config = await loadConfig(ctx);
+  const jwt = generateJWT(config.appId, config.privateKey);
+
+  const response = await ctx.net.fetch(
+    `https://api.github.com/app/installations/${config.installationId}/access_tokens`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${jwt}`,
+        "User-Agent": "cireilclaw-github-plugin",
+      },
+      method: "POST",
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ToolError(`GitHub App auth failed (${response.status}): ${text}`);
+  }
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const data = (await response.json()) as { token: string; expires_at: string };
+  cachedToken = {
+    expiresAt: Date.parse(data.expires_at),
+    token: data.token,
+  };
+
+  return data.token;
+}

--- a/packages/plugin-github/src/auth.ts
+++ b/packages/plugin-github/src/auth.ts
@@ -18,12 +18,14 @@ function b64url(obj: unknown): string {
 }
 
 function resolvePrivateKey(keyOrPath: string): string {
-  if (keyOrPath.startsWith("-----BEGIN ")) {
-    return keyOrPath;
+  const trimmed = keyOrPath.trim();
+
+  if (trimmed.startsWith("-----BEGIN ")) {
+    return trimmed;
   }
 
   try {
-    return readFileSync(keyOrPath, "utf8");
+    return readFileSync(trimmed, "utf8");
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     throw new ToolError(

--- a/packages/plugin-github/src/auth.ts
+++ b/packages/plugin-github/src/auth.ts
@@ -1,4 +1,5 @@
 import { createPrivateKey, sign } from "node:crypto";
+import { readFileSync } from "node:fs";
 
 import type { PluginToolContext } from "@cireilclaw/sdk";
 import { ToolError } from "@cireilclaw/sdk";
@@ -16,7 +17,22 @@ function b64url(obj: unknown): string {
   return Buffer.from(JSON.stringify(obj)).toString("base64url");
 }
 
-function generateJWT(appId: string, pem: string): string {
+function resolvePrivateKey(keyOrPath: string): string {
+  if (keyOrPath.startsWith("-----BEGIN ")) {
+    return keyOrPath;
+  }
+
+  try {
+    return readFileSync(keyOrPath, "utf8");
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ToolError(
+      `GitHub plugin privateKey is not PEM and could not be read as file path: ${message}`,
+    );
+  }
+}
+
+function generateJWT(appId: string, keyOrPath: string): string {
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: "RS256" as const, typ: "JWT" };
   const payload = {
@@ -26,8 +42,9 @@ function generateJWT(appId: string, pem: string): string {
   };
 
   const signingInput = `${b64url(header)}.${b64url(payload)}`;
+  const pem = resolvePrivateKey(keyOrPath);
   const key = createPrivateKey(pem);
-  const signature = sign(undefined, Buffer.from(signingInput), key);
+  const signature = sign("sha256", Buffer.from(signingInput), key);
 
   return `${signingInput}.${signature.toString("base64url")}`;
 }

--- a/packages/plugin-github/src/comments.ts
+++ b/packages/plugin-github/src/comments.ts
@@ -1,0 +1,70 @@
+import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
+import { vb } from "@cireilclaw/sdk";
+
+import { ghParse } from "./api.js";
+import type { GHComment } from "./types.js";
+
+// ── github-add-issue-comment ────────────────────────────────────────
+
+const addCommentSchema = vb.strictObject({
+  body: vb.pipe(vb.string(), vb.nonEmpty(), vb.description("Comment body (Markdown)")),
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1), vb.description("Issue or PR number")),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubAddIssueComment: ToolDef = {
+  description: "Add a comment to an issue or pull request.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number, body } = vb.parse(addCommentSchema, raw);
+    const comment = await ghParse<GHComment>(
+      ctx,
+      "POST",
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      { body },
+    );
+    return {
+      htmlUrl: comment.html_url,
+      id: comment.id,
+      success: true,
+    };
+  },
+  name: "github-add-issue-comment",
+  parameters: addCommentSchema,
+};
+
+// ── github-list-issue-comments ──────────────────────────────────────
+
+const listCommentsSchema = vb.strictObject({
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1), vb.description("Issue or PR number")),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubListIssueComments: ToolDef = {
+  description: "List comments on an issue or pull request.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number } = vb.parse(listCommentsSchema, raw);
+    const items = await ghParse<GHComment[]>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+    );
+    const comments = items.map((comment) => ({
+      author: comment.user?.login ?? undefined,
+      body: comment.body,
+      createdAt: comment.created_at,
+      htmlUrl: comment.html_url,
+      id: comment.id,
+      updatedAt: comment.updated_at,
+    }));
+    return { comments, success: true };
+  },
+  name: "github-list-issue-comments",
+  parameters: listCommentsSchema,
+};
+
+export const commentTools: Record<string, ToolDef> = {
+  "github-add-issue-comment": githubAddIssueComment,
+  "github-list-issue-comments": githubListIssueComments,
+};

--- a/packages/plugin-github/src/config.ts
+++ b/packages/plugin-github/src/config.ts
@@ -13,6 +13,21 @@ const ConfigSchema = vb.strictObject({
 let cachedConfig: Config | undefined = undefined;
 let loadPromise: Promise<Config> | undefined = undefined;
 
+function parseInstallationId(raw: string): number {
+  if (!/^\d+$/u.test(raw)) {
+    throw new ToolError(
+      `Invalid installationId "${raw}" in GitHub plugin config: expected a positive integer.`,
+    );
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new ToolError(
+      `Invalid installationId "${raw}" in GitHub plugin config: must be a positive integer.`,
+    );
+  }
+  return value;
+}
+
 async function inner(ctx: Pick<PluginToolContext, "cfg">): Promise<Config> {
   const rawConfig = await ctx.cfg.globalPlugin("github");
   if (rawConfig === undefined) {
@@ -28,7 +43,7 @@ async function inner(ctx: Pick<PluginToolContext, "cfg">): Promise<Config> {
     appId: parsed.appId,
     installationId:
       typeof parsed.installationId === "string"
-        ? Number.parseInt(parsed.installationId, 10)
+        ? parseInstallationId(parsed.installationId)
         : parsed.installationId,
     privateKey: parsed.privateKey,
   };

--- a/packages/plugin-github/src/config.ts
+++ b/packages/plugin-github/src/config.ts
@@ -40,9 +40,7 @@ export interface Config {
   installationId: number;
 }
 
-export async function loadConfig(
-  ctx: Pick<PluginToolContext, "cfg">,
-): Promise<Config> {
+export async function loadConfig(ctx: Pick<PluginToolContext, "cfg">): Promise<Config> {
   if (cachedConfig !== undefined) {
     return cachedConfig;
   }

--- a/packages/plugin-github/src/config.ts
+++ b/packages/plugin-github/src/config.ts
@@ -1,0 +1,62 @@
+import type { PluginToolContext } from "@cireilclaw/sdk";
+import { ToolError, vb } from "@cireilclaw/sdk";
+
+const ConfigSchema = vb.strictObject({
+  appId: vb.pipe(vb.string(), vb.nonEmpty()),
+  installationId: vb.union([
+    vb.pipe(vb.string(), vb.nonEmpty()),
+    vb.pipe(vb.number(), vb.integer(), vb.minValue(1)),
+  ]),
+  privateKey: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+let cachedConfig: Config | undefined = undefined;
+let loadPromise: Promise<Config> | undefined = undefined;
+
+async function inner(ctx: Pick<PluginToolContext, "cfg">): Promise<Config> {
+  const rawConfig = await ctx.cfg.globalPlugin("github");
+  if (rawConfig === undefined) {
+    throw new ToolError(
+      "GitHub plugin is not configured. " +
+        "Add appId, privateKey, and installationId to config/plugins/github.toml.",
+    );
+  }
+
+  const parsed = vb.parse(ConfigSchema, rawConfig);
+
+  return {
+    appId: parsed.appId,
+    installationId:
+      typeof parsed.installationId === "string"
+        ? Number.parseInt(parsed.installationId, 10)
+        : parsed.installationId,
+    privateKey: parsed.privateKey,
+  };
+}
+
+export interface Config {
+  appId: string;
+  privateKey: string;
+  installationId: number;
+}
+
+export async function loadConfig(
+  ctx: Pick<PluginToolContext, "cfg">,
+): Promise<Config> {
+  if (cachedConfig !== undefined) {
+    return cachedConfig;
+  }
+
+  if (loadPromise !== undefined) {
+    return loadPromise;
+  }
+
+  loadPromise = inner(ctx);
+  try {
+    const config = await loadPromise;
+    cachedConfig = config;
+    return config;
+  } finally {
+    loadPromise = undefined;
+  }
+}

--- a/packages/plugin-github/src/content.ts
+++ b/packages/plugin-github/src/content.ts
@@ -1,0 +1,139 @@
+import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
+import { ToolError, vb } from "@cireilclaw/sdk";
+
+import { ghParse } from "./api.js";
+import type { GHContent, GHSearchResult, GHCodeItem } from "./types.js";
+
+// ── github-read-file ────────────────────────────────────────────────
+
+const readFileSchema = vb.strictObject({
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  path: vb.pipe(
+    vb.string(),
+    vb.nonEmpty(),
+    vb.description("File path within the repo (e.g. src/index.ts)"),
+  ),
+  ref: vb.exactOptional(
+    vb.pipe(vb.string(), vb.description("Branch, tag, or commit SHA (default: default branch)")),
+  ),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubReadFile: ToolDef = {
+  description: "Read a file's contents from a GitHub repository.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, path, ref } = vb.parse(readFileSchema, raw);
+    const params = ref === undefined ? "" : `?ref=${encodeURIComponent(ref)}`;
+    const data = await ghParse<GHContent>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}${params}`,
+    );
+
+    if (data.type !== "file") {
+      throw new ToolError(
+        `Path "${path}" is a ${data.type}, not a file. Use github-list-contents to list it.`,
+      );
+    }
+
+    const content = Buffer.from(data.content, "base64").toString("utf8");
+    return {
+      content,
+      encoding: data.encoding,
+      htmlUrl: data.html_url,
+      name: data.name,
+      path: data.path,
+      sha: data.sha,
+      size: data.size,
+      success: true,
+    };
+  },
+  name: "github-read-file",
+  parameters: readFileSchema,
+};
+
+// ── github-list-contents ────────────────────────────────────────────
+
+const listContentsSchema = vb.strictObject({
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  path: vb.exactOptional(
+    vb.pipe(vb.string(), vb.description("Directory path (default: root)")),
+    "",
+  ),
+  ref: vb.exactOptional(
+    vb.pipe(vb.string(), vb.description("Branch, tag, or commit SHA (default: default branch)")),
+  ),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubListContents: ToolDef = {
+  description: "List files and directories in a repository path.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, path, ref } = vb.parse(listContentsSchema, raw);
+    const encPath = path === "" ? "" : `/${encodeURIComponent(path)}`;
+    const params = ref === undefined ? "" : `?ref=${encodeURIComponent(ref)}`;
+    const data = await ghParse<GHContent | GHContent[]>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/contents${encPath}${params}`,
+    );
+
+    const items = (Array.isArray(data) ? data : [data]).map((item) => ({
+      htmlUrl: item.html_url,
+      name: item.name,
+      path: item.path,
+      size: item.size,
+      type: item.type,
+    }));
+
+    return { items, success: true };
+  },
+  name: "github-list-contents",
+  parameters: listContentsSchema,
+};
+
+// ── github-search-code ──────────────────────────────────────────────
+
+const searchCodeSchema = vb.strictObject({
+  limit: vb.exactOptional(
+    vb.pipe(
+      vb.number(),
+      vb.integer(),
+      vb.minValue(1),
+      vb.maxValue(30),
+      vb.description("Max results (default 5)"),
+    ),
+    5,
+  ),
+  query: vb.pipe(
+    vb.string(),
+    vb.nonEmpty(),
+    vb.description("Search query (supports GitHub qualifiers like repo:, language:, path:)"),
+  ),
+});
+
+const githubSearchCode: ToolDef = {
+  description: "Search code across GitHub repositories.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { limit, query } = vb.parse(searchCodeSchema, raw);
+    const params = new URLSearchParams();
+    params.set("per_page", String(limit));
+    params.set("q", query);
+    const result = await ghParse<GHSearchResult<GHCodeItem>>(ctx, "GET", `/search/code?${String(params)}`);
+    const results = result.items.map((item) => ({
+      htmlUrl: item.html_url,
+      name: item.name,
+      path: item.path,
+      repo: item.repository?.full_name ?? undefined,
+    }));
+    return { results, success: true, totalCount: result.total_count };
+  },
+  name: "github-search-code",
+  parameters: searchCodeSchema,
+};
+
+export const contentTools: Record<string, ToolDef> = {
+  "github-list-contents": githubListContents,
+  "github-read-file": githubReadFile,
+  "github-search-code": githubSearchCode,
+};

--- a/packages/plugin-github/src/content.ts
+++ b/packages/plugin-github/src/content.ts
@@ -1,7 +1,7 @@
 import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
 import { ToolError, vb } from "@cireilclaw/sdk";
 
-import { ghParse } from "./api.js";
+import { gh, ghParse } from "./api.js";
 import type { GHContent, GHSearchResult, GHCodeItem } from "./types.js";
 
 // ── github-read-file ────────────────────────────────────────────────
@@ -34,6 +34,34 @@ const githubReadFile: ToolDef = {
       throw new ToolError(
         `Path "${path}" is a ${data.type}, not a file. Use github-list-contents to list it.`,
       );
+    }
+
+    if (data.encoding !== "base64" || data.content === "") {
+      // Fall back to raw endpoint for non-base64 encodings
+      const refQuery = ref === undefined ? "" : `?ref=${encodeURIComponent(ref)}`;
+      const rawResponse = await gh(
+        ctx,
+        "GET",
+        `/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}${refQuery}`,
+        undefined,
+        { Accept: "application/vnd.github.v3.raw" },
+      );
+      if (!rawResponse.ok) {
+        throw new ToolError(
+          `Failed to read file "${path}": encoding is "${data.encoding}" and raw fallback returned ${String(rawResponse.status)}.`,
+        );
+      }
+      const rawContent = await rawResponse.text();
+      return {
+        content: rawContent,
+        encoding: data.encoding,
+        htmlUrl: data.html_url,
+        name: data.name,
+        path: data.path,
+        sha: data.sha,
+        size: rawContent.length,
+        success: true,
+      };
     }
 
     const content = Buffer.from(data.content, "base64").toString("utf8");

--- a/packages/plugin-github/src/content.ts
+++ b/packages/plugin-github/src/content.ts
@@ -119,7 +119,11 @@ const githubSearchCode: ToolDef = {
     const params = new URLSearchParams();
     params.set("per_page", String(limit));
     params.set("q", query);
-    const result = await ghParse<GHSearchResult<GHCodeItem>>(ctx, "GET", `/search/code?${String(params)}`);
+    const result = await ghParse<GHSearchResult<GHCodeItem>>(
+      ctx,
+      "GET",
+      `/search/code?${String(params)}`,
+    );
     const results = result.items.map((item) => ({
       htmlUrl: item.html_url,
       name: item.name,

--- a/packages/plugin-github/src/content.ts
+++ b/packages/plugin-github/src/content.ts
@@ -19,6 +19,8 @@ const readFileSchema = vb.strictObject({
   repo: vb.pipe(vb.string(), vb.nonEmpty()),
 });
 
+const MAX_RAW_FALLBACK_BYTES = 10 * 1024 * 1024;
+
 const githubReadFile: ToolDef = {
   description: "Read a file's contents from a GitHub repository.",
   async execute(raw: unknown, ctx): Promise<ToolResult> {
@@ -37,6 +39,11 @@ const githubReadFile: ToolDef = {
     }
 
     if (data.encoding !== "base64" || data.content === "") {
+      if (data.size > MAX_RAW_FALLBACK_BYTES) {
+        throw new ToolError(
+          `File "${path}" is ${String(data.size)} bytes (max ${String(MAX_RAW_FALLBACK_BYTES)}). Use github-read-file with a ref or clone the repo locally.`,
+        );
+      }
       // Fall back to raw endpoint for non-base64 encodings
       const refQuery = ref === undefined ? "" : `?ref=${encodeURIComponent(ref)}`;
       const rawResponse = await gh(
@@ -59,7 +66,7 @@ const githubReadFile: ToolDef = {
         name: data.name,
         path: data.path,
         sha: data.sha,
-        size: rawContent.length,
+        size: data.size,
         success: true,
       };
     }

--- a/packages/plugin-github/src/index.ts
+++ b/packages/plugin-github/src/index.ts
@@ -1,0 +1,19 @@
+import { definePlugin } from "@cireilclaw/sdk";
+
+import { commentTools } from "./comments.js";
+import { contentTools } from "./content.js";
+import { issueTools } from "./issues.js";
+import { prTools } from "./pulls.js";
+import { repoTools } from "./repos.js";
+
+// oxlint-disable-next-line import/no-default-export
+export default definePlugin(() => ({
+  name: "github",
+  tools: {
+    ...issueTools,
+    ...prTools,
+    ...commentTools,
+    ...repoTools,
+    ...contentTools,
+  },
+}));

--- a/packages/plugin-github/src/issues.ts
+++ b/packages/plugin-github/src/issues.ts
@@ -1,0 +1,249 @@
+import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
+import { vb } from "@cireilclaw/sdk";
+
+import { ghParse } from "./api.js";
+import type { GHIssue, GHSearchResult } from "./types.js";
+
+// ── github-create-issue ─────────────────────────────────────────────
+
+const createIssueSchema = vb.strictObject({
+  assignees: vb.exactOptional(
+    vb.pipe(vb.array(vb.string()), vb.description("Usernames to assign")),
+  ),
+  body: vb.exactOptional(vb.pipe(vb.string(), vb.description("Issue body (Markdown)"))),
+  labels: vb.exactOptional(vb.pipe(vb.array(vb.string()), vb.description("Labels to apply"))),
+  owner: vb.pipe(vb.string(), vb.nonEmpty(), vb.description("Repository owner (user or org)")),
+  repo: vb.pipe(vb.string(), vb.nonEmpty(), vb.description("Repository name")),
+  title: vb.pipe(vb.string(), vb.nonEmpty(), vb.description("Issue title")),
+});
+
+const githubCreateIssue: ToolDef = {
+  description: "Create a new issue in a GitHub repository.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, title, body, labels, assignees } = vb.parse(createIssueSchema, raw);
+    const issue = await ghParse<GHIssue>(ctx, "POST", `/repos/${owner}/${repo}/issues`, {
+      title,
+      ...(body !== undefined && { body }),
+      ...(labels !== undefined && { labels }),
+      ...(assignees !== undefined && { assignees }),
+    });
+    return {
+      number: issue.number,
+      state: issue.state,
+      success: true,
+      title: issue.title,
+      url: issue.html_url,
+    };
+  },
+  name: "github-create-issue",
+  parameters: createIssueSchema,
+};
+
+// ── github-read-issue ───────────────────────────────────────────────
+
+const readIssueSchema = vb.strictObject({
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1), vb.description("Issue number")),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubReadIssue: ToolDef = {
+  description: "Get detailed information about a specific issue.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number } = vb.parse(readIssueSchema, raw);
+    const issue = await ghParse<GHIssue>(ctx, "GET", `/repos/${owner}/${repo}/issues/${String(number)}`);
+    return {
+      assignees: issue.assignees.map((user) => user.login),
+      body: issue.body,
+      comments: issue.comments,
+      createdAt: issue.created_at,
+      htmlUrl: issue.html_url,
+      labels: issue.labels.map((label) => (typeof label === "string" ? label : label.name)),
+      number: issue.number,
+      state: issue.state,
+      success: true,
+      title: issue.title,
+      updatedAt: issue.updated_at,
+      user: issue.user?.login ?? undefined,
+    };
+  },
+  name: "github-read-issue",
+  parameters: readIssueSchema,
+};
+
+// ── github-list-issues ──────────────────────────────────────────────
+
+const listIssuesSchema = vb.strictObject({
+  assignee: vb.exactOptional(vb.pipe(vb.string(), vb.description("Filter by assignee username"))),
+  direction: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["asc", "desc"] as const),
+      vb.description("Sort direction (default: desc)"),
+    ),
+    "desc",
+  ),
+  labels: vb.exactOptional(
+    vb.pipe(vb.string(), vb.description("Comma-separated list of label names to filter by")),
+  ),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  perPage: vb.exactOptional(
+    vb.pipe(
+      vb.number(),
+      vb.integer(),
+      vb.minValue(1),
+      vb.maxValue(100),
+      vb.description("Results per page (max 100)"),
+    ),
+    20,
+  ),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+  sort: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["created", "updated", "comments"] as const),
+      vb.description("Sort field (default: created)"),
+    ),
+    "created",
+  ),
+  state: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["open", "closed", "all"] as const),
+      vb.description("Filter by state (default: open)"),
+    ),
+    "open",
+  ),
+});
+
+const githubListIssues: ToolDef = {
+  description: "List issues in a repository with optional filters.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, state, labels, assignee, sort, direction, perPage } = vb.parse(
+      listIssuesSchema,
+      raw,
+    );
+    const params = new URLSearchParams({ direction, per_page: String(perPage), sort, state });
+    if (labels !== undefined) {
+      params.set("labels", labels);
+    }
+    if (assignee !== undefined) {
+      params.set("assignee", assignee);
+    }
+
+    const items = await ghParse<GHIssue[]>(ctx, "GET", `/repos/${owner}/${repo}/issues?${String(params)}`);
+    const issues = items
+      .filter((item) => item.pull_request === undefined)
+      .map((item) => ({
+        assignees: item.assignees.map((user) => user.login),
+        comments: item.comments,
+        createdAt: item.created_at,
+        htmlUrl: item.html_url,
+        labels: item.labels.map((label) => (typeof label === "string" ? label : label.name)),
+        number: item.number,
+        state: item.state,
+        title: item.title,
+        updatedAt: item.updated_at,
+        user: item.user?.login ?? undefined,
+      }));
+    return { issues, success: true };
+  },
+  name: "github-list-issues",
+  parameters: listIssuesSchema,
+};
+
+// ── github-update-issue ─────────────────────────────────────────────
+
+const updateIssueSchema = vb.strictObject({
+  body: vb.exactOptional(vb.pipe(vb.string(), vb.description("New body (Markdown)"))),
+  labels: vb.exactOptional(vb.pipe(vb.array(vb.string()), vb.description("Replacement labels"))),
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1)),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+  state: vb.exactOptional(
+    vb.pipe(vb.picklist(["open", "closed"] as const), vb.description("New state")),
+  ),
+  title: vb.exactOptional(vb.pipe(vb.string(), vb.description("New title"))),
+});
+
+const githubUpdateIssue: ToolDef = {
+  description: "Update an existing issue's title, body, state, or labels.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number, title, body, state, labels } = vb.parse(updateIssueSchema, raw);
+    const payload: Record<string, unknown> = {};
+    if (title !== undefined) {
+      payload["title"] = title;
+    }
+    if (body !== undefined) {
+      payload["body"] = body;
+    }
+    if (state !== undefined) {
+      payload["state"] = state;
+    }
+    if (labels !== undefined) {
+      payload["labels"] = labels;
+    }
+
+    const issue = await ghParse<GHIssue>(
+      ctx,
+      "PATCH",
+      `/repos/${owner}/${repo}/issues/${String(number)}`,
+      payload,
+    );
+    return {
+      number: issue.number,
+      state: issue.state,
+      success: true,
+      title: issue.title,
+      url: issue.html_url,
+    };
+  },
+  name: "github-update-issue",
+  parameters: updateIssueSchema,
+};
+
+// ── github-search-issues ────────────────────────────────────────────
+
+const searchIssuesSchema = vb.strictObject({
+  limit: vb.exactOptional(
+    vb.pipe(
+      vb.number(),
+      vb.integer(),
+      vb.minValue(1),
+      vb.maxValue(50),
+      vb.description("Max results (default 10)"),
+    ),
+    10,
+  ),
+  query: vb.pipe(
+    vb.string(),
+    vb.nonEmpty(),
+    vb.description("Search query (supports GitHub qualifiers like repo:, label:, is:open)"),
+  ),
+});
+
+const githubSearchIssues: ToolDef = {
+  description: "Search for issues and pull requests across GitHub using full-text search.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { limit, query } = vb.parse(searchIssuesSchema, raw);
+    const params = new URLSearchParams();
+    params.set("per_page", String(limit));
+    params.set("q", query);
+    const result = await ghParse<GHSearchResult<GHIssue>>(ctx, "GET", `/search/issues?${String(params)}`);
+    const results = result.items.map((item) => ({
+      htmlUrl: item.html_url,
+      number: item.number,
+      state: item.state,
+      title: item.title,
+      user: item.user?.login ?? undefined,
+    }));
+    return { results, success: true, totalCount: result.total_count };
+  },
+  name: "github-search-issues",
+  parameters: searchIssuesSchema,
+};
+
+export const issueTools: Record<string, ToolDef> = {
+  "github-create-issue": githubCreateIssue,
+  "github-list-issues": githubListIssues,
+  "github-read-issue": githubReadIssue,
+  "github-search-issues": githubSearchIssues,
+  "github-update-issue": githubUpdateIssue,
+};

--- a/packages/plugin-github/src/issues.ts
+++ b/packages/plugin-github/src/issues.ts
@@ -51,7 +51,11 @@ const githubReadIssue: ToolDef = {
   description: "Get detailed information about a specific issue.",
   async execute(raw: unknown, ctx): Promise<ToolResult> {
     const { owner, repo, number } = vb.parse(readIssueSchema, raw);
-    const issue = await ghParse<GHIssue>(ctx, "GET", `/repos/${owner}/${repo}/issues/${String(number)}`);
+    const issue = await ghParse<GHIssue>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/issues/${String(number)}`,
+    );
     return {
       assignees: issue.assignees.map((user) => user.login),
       body: issue.body,
@@ -128,7 +132,11 @@ const githubListIssues: ToolDef = {
       params.set("assignee", assignee);
     }
 
-    const items = await ghParse<GHIssue[]>(ctx, "GET", `/repos/${owner}/${repo}/issues?${String(params)}`);
+    const items = await ghParse<GHIssue[]>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/issues?${String(params)}`,
+    );
     const issues = items
       .filter((item) => item.pull_request === undefined)
       .map((item) => ({
@@ -226,7 +234,11 @@ const githubSearchIssues: ToolDef = {
     const params = new URLSearchParams();
     params.set("per_page", String(limit));
     params.set("q", query);
-    const result = await ghParse<GHSearchResult<GHIssue>>(ctx, "GET", `/search/issues?${String(params)}`);
+    const result = await ghParse<GHSearchResult<GHIssue>>(
+      ctx,
+      "GET",
+      `/search/issues?${String(params)}`,
+    );
     const results = result.items.map((item) => ({
       htmlUrl: item.html_url,
       number: item.number,

--- a/packages/plugin-github/src/pulls.ts
+++ b/packages/plugin-github/src/pulls.ts
@@ -1,7 +1,7 @@
 import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
 import { vb } from "@cireilclaw/sdk";
 
-import { ghParse } from "./api.js";
+import { ghPaginate, ghParse } from "./api.js";
 import type { GHPullRequest, GHPrFile } from "./types.js";
 
 // ── github-read-pr ──────────────────────────────────────────────────
@@ -139,10 +139,9 @@ const githubListPrFiles: ToolDef = {
   description: "List files changed in a pull request.",
   async execute(raw: unknown, ctx): Promise<ToolResult> {
     const { owner, repo, number } = vb.parse(listPrFilesSchema, raw);
-    const items = await ghParse<GHPrFile[]>(
+    const items = await ghPaginate<GHPrFile>(
       ctx,
-      "GET",
-      `/repos/${owner}/${repo}/pulls/${String(number)}/files`,
+      `/repos/${owner}/${repo}/pulls/${String(number)}/files?per_page=100`,
     );
     const files = items.map((file) => ({
       additions: file.additions,

--- a/packages/plugin-github/src/pulls.ts
+++ b/packages/plugin-github/src/pulls.ts
@@ -1,0 +1,164 @@
+import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
+import { vb } from "@cireilclaw/sdk";
+
+import { ghParse } from "./api.js";
+import type { GHPullRequest, GHPrFile } from "./types.js";
+
+// ── github-read-pr ──────────────────────────────────────────────────
+
+const readPrSchema = vb.strictObject({
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1), vb.description("PR number")),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubReadPr: ToolDef = {
+  description: "Get detailed information about a specific pull request.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number } = vb.parse(readPrSchema, raw);
+    const pr = await ghParse<GHPullRequest>(ctx, "GET", `/repos/${owner}/${repo}/pulls/${String(number)}`);
+    return {
+      additions: pr.additions,
+      base: pr.base.ref,
+      body: pr.body,
+      changedFiles: pr.changed_files,
+      closedAt: pr.closed_at,
+      comments: pr.comments,
+      commits: pr.commits,
+      createdAt: pr.created_at,
+      deletions: pr.deletions,
+      draft: pr.draft,
+      head: pr.head.ref,
+      headRepo: pr.head.repo?.full_name ?? undefined,
+      htmlUrl: pr.html_url,
+      mergeable: pr.mergeable,
+      merged: pr.merged,
+      mergedAt: pr.merged_at,
+      number: pr.number,
+      state: pr.state,
+      success: true,
+      title: pr.title,
+      url: pr.html_url,
+      user: pr.user?.login ?? undefined,
+    };
+  },
+  name: "github-read-pr",
+  parameters: readPrSchema,
+};
+
+// ── github-list-prs ─────────────────────────────────────────────────
+
+const listPrsSchema = vb.strictObject({
+  base: vb.exactOptional(vb.pipe(vb.string(), vb.description("Filter by base branch name"))),
+  direction: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["asc", "desc"] as const),
+      vb.description("Sort direction (default: desc)"),
+    ),
+    "desc",
+  ),
+  head: vb.exactOptional(vb.pipe(vb.string(), vb.description("Filter by head branch name"))),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  perPage: vb.exactOptional(
+    vb.pipe(
+      vb.number(),
+      vb.integer(),
+      vb.minValue(1),
+      vb.maxValue(100),
+      vb.description("Results per page (max 100)"),
+    ),
+    20,
+  ),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+  sort: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["created", "updated", "popularity", "long-running"] as const),
+      vb.description("Sort field (default: created)"),
+    ),
+    "created",
+  ),
+  state: vb.exactOptional(
+    vb.pipe(
+      vb.picklist(["open", "closed", "all"] as const),
+      vb.description("Filter by state (default: open)"),
+    ),
+    "open",
+  ),
+});
+
+const githubListPrs: ToolDef = {
+  description: "List pull requests in a repository with optional filters.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, state, head, base, sort, direction, perPage } = vb.parse(
+      listPrsSchema,
+      raw,
+    );
+    const params = new URLSearchParams({ direction, per_page: String(perPage), sort, state });
+    if (head !== undefined) {
+      params.set("head", head);
+    }
+    if (base !== undefined) {
+      params.set("base", base);
+    }
+
+    const items = await ghParse<GHPullRequest[]>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/pulls?${params.toString()}`,
+    );
+    const prs = items.map((pr) => ({
+      createdAt: pr.created_at,
+      draft: pr.draft,
+      head: pr.head.ref,
+      htmlUrl: pr.html_url,
+      number: pr.number,
+      state: pr.state,
+      title: pr.title,
+      updatedAt: pr.updated_at,
+      user: pr.user?.login ?? undefined,
+    }));
+    return { prs, success: true };
+  },
+  name: "github-list-prs",
+  parameters: listPrsSchema,
+};
+
+// ── github-list-pr-files ────────────────────────────────────────────
+
+const listPrFilesSchema = vb.strictObject({
+  number: vb.pipe(vb.number(), vb.integer(), vb.minValue(1)),
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubListPrFiles: ToolDef = {
+  description: "List files changed in a pull request.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo, number } = vb.parse(listPrFilesSchema, raw);
+    const items = await ghParse<GHPrFile[]>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/pulls/${String(number)}/files`,
+    );
+    const files = items.map((file) => ({
+      additions: file.additions,
+      blobUrl: file.blob_url,
+      changes: file.changes,
+      contentsUrl: file.contents_url,
+      deletions: file.deletions,
+      filename: file.filename,
+      patch: file.patch,
+      rawUrl: file.raw_url,
+      status: file.status,
+    }));
+    return { files, success: true };
+  },
+  name: "github-list-pr-files",
+  parameters: listPrFilesSchema,
+};
+
+export const prTools: Record<string, ToolDef> = {
+  "github-list-pr-files": githubListPrFiles,
+  "github-list-prs": githubListPrs,
+  "github-read-pr": githubReadPr,
+};

--- a/packages/plugin-github/src/pulls.ts
+++ b/packages/plugin-github/src/pulls.ts
@@ -16,7 +16,11 @@ const githubReadPr: ToolDef = {
   description: "Get detailed information about a specific pull request.",
   async execute(raw: unknown, ctx): Promise<ToolResult> {
     const { owner, repo, number } = vb.parse(readPrSchema, raw);
-    const pr = await ghParse<GHPullRequest>(ctx, "GET", `/repos/${owner}/${repo}/pulls/${String(number)}`);
+    const pr = await ghParse<GHPullRequest>(
+      ctx,
+      "GET",
+      `/repos/${owner}/${repo}/pulls/${String(number)}`,
+    );
     return {
       additions: pr.additions,
       base: pr.base.ref,

--- a/packages/plugin-github/src/repos.ts
+++ b/packages/plugin-github/src/repos.ts
@@ -1,0 +1,68 @@
+import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
+import { vb } from "@cireilclaw/sdk";
+
+import { ghParse } from "./api.js";
+import type { GHRepo, GHInstallationRepos } from "./types.js";
+
+// ── github-list-repos ───────────────────────────────────────────────
+
+const githubListRepos: ToolDef = {
+  description: "List repositories the GitHub App installation has access to.",
+  async execute(_raw: unknown, ctx): Promise<ToolResult> {
+    const result = await ghParse<GHInstallationRepos>(ctx, "GET", "/installation/repositories");
+    const repos = result.repositories.map((repo) => ({
+      defaultBranch: repo.default_branch,
+      description: repo.description,
+      fullName: repo.full_name,
+      htmlUrl: repo.html_url,
+      language: repo.language,
+      name: repo.name,
+      owner: repo.owner?.login ?? undefined,
+      private: repo.private,
+      updatedAt: repo.updated_at,
+    }));
+    return { repos, success: true };
+  },
+  name: "github-list-repos",
+  parameters: vb.strictObject({}),
+};
+
+// ── github-read-repo ────────────────────────────────────────────────
+
+const readRepoSchema = vb.strictObject({
+  owner: vb.pipe(vb.string(), vb.nonEmpty()),
+  repo: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+const githubReadRepo: ToolDef = {
+  description: "Get metadata about a repository.",
+  async execute(raw: unknown, ctx): Promise<ToolResult> {
+    const { owner, repo } = vb.parse(readRepoSchema, raw);
+    const repoData = await ghParse<GHRepo>(ctx, "GET", `/repos/${owner}/${repo}`);
+    return {
+      defaultBranch: repoData.default_branch,
+      description: repoData.description,
+      fork: repoData.fork,
+      forksCount: repoData.forks_count,
+      fullName: repoData.full_name,
+      htmlUrl: repoData.html_url,
+      language: repoData.language,
+      openIssuesCount: repoData.open_issues_count,
+      owner: repoData.owner?.login ?? undefined,
+      private: repoData.private,
+      stargazersCount: repoData.stargazers_count,
+      success: true,
+      topics: repoData.topics,
+      updatedAt: repoData.updated_at,
+      visibility: repoData.visibility,
+      watchersCount: repoData.watchers_count,
+    };
+  },
+  name: "github-read-repo",
+  parameters: readRepoSchema,
+};
+
+export const repoTools: Record<string, ToolDef> = {
+  "github-list-repos": githubListRepos,
+  "github-read-repo": githubReadRepo,
+};

--- a/packages/plugin-github/src/repos.ts
+++ b/packages/plugin-github/src/repos.ts
@@ -1,16 +1,37 @@
 import type { ToolDef, ToolResult } from "@cireilclaw/sdk";
-import { vb } from "@cireilclaw/sdk";
+import { ToolError, vb } from "@cireilclaw/sdk";
 
-import { ghParse } from "./api.js";
-import type { GHRepo, GHInstallationRepos } from "./types.js";
+import { gh, ghParse, parseLinkNext } from "./api.js";
+import type { GHRepo } from "./types.js";
 
 // ── github-list-repos ───────────────────────────────────────────────
+
+interface GHInstallationReposPage {
+  repositories: GHRepo[];
+  total_count: number;
+}
 
 const githubListRepos: ToolDef = {
   description: "List repositories the GitHub App installation has access to.",
   async execute(_raw: unknown, ctx): Promise<ToolResult> {
-    const result = await ghParse<GHInstallationRepos>(ctx, "GET", "/installation/repositories");
-    const repos = result.repositories.map((repo) => ({
+    const allRepos: GHRepo[] = [];
+    let nextUrl: string | undefined = "/installation/repositories?per_page=100";
+
+    while (nextUrl !== undefined) {
+      const response = await gh(ctx, "GET", nextUrl);
+      if (!response.ok) {
+        const text = await response.text();
+        throw new ToolError(`GitHub API error (${response.status}): ${text}`);
+      }
+
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      const data = (await response.json()) as GHInstallationReposPage;
+      allRepos.push(...data.repositories);
+
+      nextUrl = parseLinkNext(response.headers.get("link") ?? undefined);
+    }
+
+    const repos = allRepos.map((repo) => ({
       defaultBranch: repo.default_branch,
       description: repo.description,
       fullName: repo.full_name,

--- a/packages/plugin-github/src/types.ts
+++ b/packages/plugin-github/src/types.ts
@@ -1,0 +1,162 @@
+// GitHub REST API response shapes (snake_case matching API)
+
+interface GHUser {
+  login: string;
+  [key: string]: unknown;
+}
+
+interface GHLabel {
+  name: string;
+  [key: string]: unknown;
+}
+
+interface GHLicense {
+  key: string;
+  name: string;
+  spdx_id: string;
+  [key: string]: unknown;
+}
+
+interface GHRepo {
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  private: boolean;
+  fork: boolean;
+  language: string | null;
+  default_branch: string;
+  visibility: string;
+  owner: GHUser | null;
+  topics: string[];
+  forks_count: number;
+  open_issues_count: number;
+  stargazers_count: number;
+  watchers_count: number;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+interface GHIssue {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  body: string | null;
+  comments: number;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  labels: GHLabel[] | string[];
+  assignees: GHUser[];
+  user: GHUser | null;
+  pull_request?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface GHPullRequest {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  body: string | null;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  merged_at: string | null;
+  draft: boolean;
+  merged: boolean;
+  mergeable: boolean | null;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  comments: number;
+  commits: number;
+  user: GHUser | null;
+  head: GHBranch;
+  base: GHBranch;
+  [key: string]: unknown;
+}
+
+interface GHBranch {
+  ref: string;
+  repo?: { full_name: string } | null;
+  [key: string]: unknown;
+}
+
+interface GHPrFile {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  blob_url: string;
+  raw_url: string;
+  contents_url: string;
+  patch?: string;
+  [key: string]: unknown;
+}
+
+interface GHComment {
+  id: number;
+  body: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  user: GHUser | null;
+  [key: string]: unknown;
+}
+
+interface GHContent {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  type: "file" | "dir" | "symlink" | "submodule";
+  content: string;
+  encoding: string;
+  html_url: string;
+  [key: string]: unknown;
+}
+
+interface GHInstallationRepos {
+  repositories: GHRepo[];
+  total_count: number;
+  [key: string]: unknown;
+}
+
+interface GHSearchResult<Item> {
+  items: Item[];
+  total_count: number;
+  [key: string]: unknown;
+}
+
+interface GHCodeItem {
+  name: string;
+  path: string;
+  html_url: string;
+  repository?: { full_name: string } | null;
+  [key: string]: unknown;
+}
+
+interface GHAccessToken {
+  token: string;
+  expires_at: string;
+  [key: string]: unknown;
+}
+
+export type {
+  GHAccessToken,
+  GHBranch,
+  GHCodeItem,
+  GHComment,
+  GHContent,
+  GHInstallationRepos,
+  GHIssue,
+  GHLabel,
+  GHLicense,
+  GHPrFile,
+  GHPullRequest,
+  GHRepo,
+  GHSearchResult,
+  GHUser,
+}

--- a/packages/plugin-github/src/types.ts
+++ b/packages/plugin-github/src/types.ts
@@ -159,4 +159,4 @@ export type {
   GHRepo,
   GHSearchResult,
   GHUser,
-}
+};

--- a/packages/plugin-github/tsconfig.json
+++ b/packages/plugin-github/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "nodenext",
+    "moduleDetection": "force",
+    "allowJs": true,
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true
+  }
+}

--- a/packages/plugin-github/tsdown.config.ts
+++ b/packages/plugin-github/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+// oxlint-disable-next-line eslint-plugin-import/no-default-export -- tsdown requires default export
+export default defineConfig({
+  clean: true,
+  deps: { neverBundle: ["@cireilclaw/sdk"] },
+  dts: true,
+  entry: ["src/index.ts"],
+  format: "esm",
+  sourcemap: true,
+  target: "node22",
+});

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cireilclaw/plugin-template",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "files": [
     "src",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,18 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/plugin-github:
+    devDependencies:
+      '@cireilclaw/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/runtime:
     dependencies:
       '@cireilclaw/sdk':
@@ -641,105 +653,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -985,56 +981,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.53.0':
     resolution: {integrity: sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
     resolution: {integrity: sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
     resolution: {integrity: sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.53.0':
     resolution: {integrity: sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.53.0':
     resolution: {integrity: sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.53.0':
     resolution: {integrity: sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.53.0':
     resolution: {integrity: sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.53.0':
     resolution: {integrity: sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==}
@@ -1137,56 +1125,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.68.0':
     resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.68.0':
     resolution: {integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.68.0':
     resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.68.0':
     resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.68.0':
     resolution: {integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.68.0':
     resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.68.0':
     resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
@@ -1280,84 +1260,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.0':
     resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.0':
     resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.0':
     resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.0':
     resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -1449,28 +1417,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@snazzah/davey-linux-arm64-musl@0.1.11':
     resolution: {integrity: sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@snazzah/davey-linux-x64-gnu@0.1.11':
     resolution: {integrity: sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@snazzah/davey-linux-x64-musl@0.1.11':
     resolution: {integrity: sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@snazzah/davey-wasm32-wasi@0.1.11':
     resolution: {integrity: sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==}
@@ -2164,28 +2128,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
Adds `@cireilclaw/plugin-github`, a full-featured GitHub App integration plugin with 15 tools across 5 domains.

**Tools:**

| Domain | Tools |
|---|---|
| Issues | `github-create-issue`, `github-read-issue`, `github-list-issues`, `github-update-issue`, `github-search-issues` |
| Comments | `github-add-issue-comment`, `github-list-issue-comments` |
| Pull Requests | `github-read-pr`, `github-list-prs`, `github-list-pr-files` |
| Repos | `github-list-repos`, `github-read-repo` |
| Content | `github-read-file`, `github-list-contents`, `github-search-code` |

**Auth:** GitHub App JWT → installation token flow via `node:crypto`, cached for 1-hour expiry.

**Other changes:**
- Patch bumps on `@cireilclaw/plugin-brave-search` (0.2.2 → 0.2.3), `@cireilclaw/plugin-openweather` (0.1.2 → 0.1.3), `@cireilclaw/plugin-template` (0.1.1 → 0.1.2)
- Root `publish:all` script publishes all `@cireilclaw/*` packages, excluding runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security Considerations — additions & clarifications

- Private key input trimming
  - resolvePrivateKey trims the configured privateKey (keyOrPath.trim()) before detecting PEM. This handles accidental surrounding whitespace or pasted file-path artifacts and prevents false negatives when a PEM is supplied with extra whitespace.

- Extra headers passthrough
  - gh and ghParse accept an extraHeaders?: Record<string, string> and merge/forward them into requests (headers spread with ...extraHeaders). Callers can supply custom Accept or other headers which will be forwarded to GitHub.

- Raw fallback size cap
  - github-read-file enforces MAX_RAW_FALLBACK_BYTES = 10 * 1024 * 1024 (10 MB). If GitHub's reported data.size exceeds this limit the plugin throws a ToolError and does not download the raw blob.

- JWT/token handling
  - JWT is built by base64url-encoding header/payload and signing with Node's crypto using createPrivateKey(pem) and sign("sha256", ...), producing an RS256 JWT. The installation token is fetched and cached in module scope with expiresAt from GitHub's expires_at and reused until 2 minutes before expiry.

- URL handling & pagination
  - gh constructs request URLs with new URL(path, "https://api.github.com") so absolute next links returned by GitHub are supported. parseLinkNext extracts rel="next" links and ghPaginate follows them while throwing on non-OK responses.

## Potential risks / reviewer attention items

- File-read error exposure
  - resolvePrivateKey will read a file path and, on failure, throw a ToolError containing the underlying fs error message. Reviewers should confirm whether exposing underlying I/O error text is acceptable in this environment.

- Forwarded headers surface
  - Because extraHeaders are merged directly into request headers, callers can override Accept/Authorization/User-Agent if they provide those keys. Ensure callers are trusted or validate/whitelist allowed headers if that’s a concern.

- Minimal runtime shape validation
  - ghParse and other callers cast JSON responses to typed shapes with unsafe assertions. While many fields are checked at runtime where branching depends on them (e.g., data.type, data.size), other fields rely on assumptions; consider adding targeted runtime checks for fields that gate behavior.

## Confirmed mitigations already present
- Trimming of privateKey input before PEM detection
- resolvePrivateKey supports PEM string or filesystem path with explicit error on read failure
- JWT created with createPrivateKey + explicit signing digest for RS256
- Installation token caching with a 2-minute expiry buffer
- Raw content fallback guarded by GitHub-reported data.size and capped at 10 MB
- gh/ghParse support extraHeaders forwarding and build URLs to handle absolute GitHub pagination links
- loadConfig memoization and concurrency deduplication
<!-- end of auto-generated comment: release notes by coderabbit.ai -->