### PR TITLE
fix: delete/reroll message commands fail when message not found in session history

### DIFF
--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -963,7 +963,10 @@ async function handleMessageUpdate(
       return;
     }
 
-    const entryIndex = session.history.findIndex((historyMsg) => historyMsg.id === msg.id);
+    const entryIndex = session.history.findIndex(
+      (historyMsg) =>
+        historyMsg.id === msg.id || (historyMsg.messageIds?.includes(msg.id) ?? false),
+    );
     if (entryIndex === -1) {
       return;
     }
@@ -1030,7 +1033,10 @@ async function handleMessageDelete(ctx: HandlerCtx, msg: PossiblyUncachedMessage
       return;
     }
 
-    const entryIndex = session.history.findIndex((historyMsg) => historyMsg.id === msg.id);
+    const entryIndex = session.history.findIndex(
+      (historyMsg) =>
+        historyMsg.id === msg.id || (historyMsg.messageIds?.includes(msg.id) ?? false),
+    );
     if (entryIndex === -1) {
       return;
     }

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -1244,14 +1244,19 @@ async function startDiscord(owner: Harness, agentSlug: string): Promise<OceanicC
             )
           : undefined;
 
+      const sentIds: string[] = [];
       for (const [idx, chunk] of chunks.entries()) {
         const isLast = idx === chunks.length - 1;
-        await client.rest.channels.createMessage(ds.channelId, {
+        const sent = await client.rest.channels.createMessage(ds.channelId, {
           content: chunk,
           flags,
           ...(isLast && files !== undefined ? { files } : {}),
         });
+        sentIds.push(sent.id);
       }
+      // Store sent message IDs so the engine can assign them to the
+      // assistant history entry after it's pushed.
+      ds.lastSentMessageIds = sentIds;
     },
   };
 

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -77,7 +77,9 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
     session.busy = true;
     saveSession(ctx.agentSlug, session);
     try {
-      const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+      const msgIndex = session.history.findIndex(
+        (entry) => entry.id === targetMsg.id || (entry.messageIds?.includes(targetMsg.id) ?? false),
+      );
       if (msgIndex === -1) {
         await interaction.createFollowup({
           content: "Cannot delete a message not found in session history.",

--- a/packages/runtime/src/channels/discord/reroll-command.ts
+++ b/packages/runtime/src/channels/discord/reroll-command.ts
@@ -83,7 +83,9 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
     session.busy = true;
     let typingInterval: ReturnType<typeof setInterval> | undefined = undefined;
     try {
-      const msgIndex = session.history.findIndex((entry) => entry.id === targetMsg.id);
+      const msgIndex = session.history.findIndex(
+        (entry) => entry.id === targetMsg.id || (entry.messageIds?.includes(targetMsg.id) ?? false),
+      );
       if (msgIndex === -1) {
         await interaction.createFollowup({
           content: "Could not find this message in session history.",

--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -596,6 +596,20 @@ export async function runTurn(
     }
 
     if (done) {
+      // Apply sent message IDs from the channel handler to the assistant
+      // history entry, so delete/reroll commands can look up by Discord ID.
+      if (session.lastSentMessageIds !== undefined && session.lastSentMessageIds.length > 0) {
+        const lastAssistant = session.history.findLast(
+          (entry) => entry.role === "assistant" && entry.id === undefined,
+        );
+        if (lastAssistant !== undefined) {
+          const [firstId, ...restIds] = session.lastSentMessageIds;
+          lastAssistant.id = firstId;
+          lastAssistant.messageIds = restIds.length > 0 ? session.lastSentMessageIds : undefined;
+        }
+        session.lastSentMessageIds = undefined;
+      }
+
       for (const msg of session.pendingToolMessages) {
         msg.timestamp ??= Date.now();
       }

--- a/packages/runtime/src/engine/message.ts
+++ b/packages/runtime/src/engine/message.ts
@@ -17,6 +17,9 @@ interface BaseMessage {
   timestamp?: number;
   // Optional unique ID for message deduplication across turns.
   id?: string;
+  // Additional message IDs for the same logical message (e.g. chunked Discord messages).
+  // The primary `id` holds the first chunk's ID; messageIds holds all chunk IDs.
+  messageIds?: string[];
 }
 
 type UserContent = TextContent | ImageContent | ImageRef | VideoContent | VideoRef;

--- a/packages/runtime/src/harness/session.ts
+++ b/packages/runtime/src/harness/session.ts
@@ -42,6 +42,11 @@ abstract class BaseSession {
   public lastContextWarningCursor?: number;
   public historyBarrier?: number;
 
+  // Temporary storage for message IDs from the most recent send call.
+  // Used by the Discord channel handler to pass sent message IDs back to the
+  // engine so the assistant history entry gets its `id` and `messageIds` set.
+  public lastSentMessageIds?: string[];
+
   public sendFilter?: (content: string) => boolean = undefined;
 
   public abstract id(): string;
@@ -58,6 +63,7 @@ abstract class BaseSession {
     this.pendingVideos = [];
     this.lastContextWarningCursor = undefined;
     this.stopRequested = false;
+    this.lastSentMessageIds = undefined;
   }
 }
 


### PR DESCRIPTION
## Problem

Delete Message and Reroll Response context menu commands fail with "Cannot delete a message not found in session history." when the target message is a bot response.

## Root cause

The Discord `send` handler called `createMessage` but discarded the returned message ID. The assistant entry in `session.history` was pushed with `id: undefined`. When delete/reroll looked up `entry.id === targetMsg.id`, it compared `undefined` against a Discord snowflake string — always `false`.

## Details

| Commit | Change |
|---|---|
| `d1f21e3` | Add `messageIds` to `BaseMessage` + `lastSentMessageIds` to `BaseSession` |
| `d74e887` | Capture `createMessage` result IDs in Discord send handler |
| `223d6f6` | Check `messageIds` in `handleMessageUpdate` / `handleMessageDelete` lookups |
| `c7ded11` | Apply sent IDs to assistant history entry on turn completion |
| `00579a2` | Check `messageIds` in delete/reroll command lookups |

The fix handles chunked messages: the first chunk's ID becomes `entry.id`, and all chunk IDs are stored in `entry.messageIds` so right-clicking any chunk resolves correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR does not introduce any security-critical changes affecting Path Isolation/Verification, Sandbox, or Parsing and Validation subsystems.

Beyond what the PR summary covers, the implementation has a minor code clarity note: Line 608 of `engine/index.ts` assigns `session.lastSentMessageIds` (the full array) to `messageIds` rather than just `restIds`. This is functionally correct if `messageIds` is intended to hold all chunk IDs including the primary one (as the comment states), but the logic could be written more clearly as `restIds.length > 0 ? restIds : undefined`. This is not a bug—just a minor inefficiency where the first message ID is stored twice (once in `id` and again in `messageIds`).

The PR correctly uses Discord.js's type-safe API for message IDs and only uses them in safe comparison operations where they cannot be exploited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->