### PR TITLE
Extend the plugins' isolation surface area

### DIFF
--- a/docs/plugins/developers.md
+++ b/docs/plugins/developers.md
@@ -185,6 +185,15 @@ interface PluginToolContext {
     agentPlugin(name: string): Promise<Record<string, unknown> | undefined>;
   };
   createKeyPool(keys: string | string[], cooldownMs?: number): KeyPool;
+  crypto: {
+    loadNormalizedKey(opts: { path: string } | { data: string }): Promise<WebCryptoFormat>;
+  };
+  fs: {
+    readTextFile(sandboxPath: string): Promise<string>;
+    writeTextFile(sandboxPath: string, content: string): Promise<void>;
+    stat(sandboxPath: string): Promise<FsStat>;
+    listDir(sandboxPath: string): Promise<FsDirent[]>;
+  };
   net: { fetch: typeof fetch };
   mounts?: readonly Mount[];
   addImage(data: Uint8Array, mediaType: string): void;
@@ -206,6 +215,7 @@ Notes:
 - `paths.resolve` converts a sandbox path (e.g. `/workspace/file.txt`) to the real filesystem path, applying mount mappings. Use this when you need to interact with files outside the RPC boundary.
 - `paths.checkWriteAccess` validates whether a sandbox path is writable under the current mount configuration. Throws if the path is read-only or outside allowed mounts.
 - `paths.checkConditionalAccess` validates whether a sandbox path is accessible in the current session context according to `conditions.toml` rules. Throws if access is denied. No-op when no conditions are configured.
+- `crypto.loadNormalizedKey` normalizes a key (PEM or DER, given as inline data or a sandbox path) to a Web-Crypto-compatible PKCS#8 private key or SPKI public key. It auto-detects PKCS#1, SEC1, and other legacy formats. Useful before calling `crypto.subtle.importKey` in plugins that need JWT signing or cryptographic operations.
 
 ## SDK Exports
 
@@ -218,6 +228,7 @@ From `@cireilclaw/sdk`:
 - `KeyPool`, `KeyPoolManager`: API key rotation with cooldown.
 - `ToolError`: semantic tool-failure exception.
 - `toWebp`, `toJpeg`, `scaleForAnthropic`: image helpers for vision-capable agents.
+- `pemToDer`, `base64urlEncode`, `base64urlDecode`: PEM-to-DER and base64url encoding utilities.
 - `vb`: reexport of `valibot`, so you don't need a separate dependency.
 
 ## Worker Isolation: What It Gives You, What It Doesn't

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -33,6 +33,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@cireilclaw/sdk": "^0.4.0"
+    "@cireilclaw/sdk": "^0.5.0"
   }
 }

--- a/packages/openweather/package.json
+++ b/packages/openweather/package.json
@@ -33,6 +33,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@cireilclaw/sdk": "^0.4.0"
+    "@cireilclaw/sdk": "^0.5.0"
   }
 }

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -33,6 +33,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@cireilclaw/sdk": "^0.4.0"
+    "@cireilclaw/sdk": "^0.5.0"
   }
 }

--- a/packages/plugin-github/src/auth.ts
+++ b/packages/plugin-github/src/auth.ts
@@ -1,8 +1,5 @@
-import { createPrivateKey, sign } from "node:crypto";
-import { readFileSync } from "node:fs";
-
+import { pemToDer, base64urlEncode, ToolError } from "@cireilclaw/sdk";
 import type { PluginToolContext } from "@cireilclaw/sdk";
-import { ToolError } from "@cireilclaw/sdk";
 
 import { loadConfig } from "./config.js";
 
@@ -13,28 +10,11 @@ interface TokenEntry {
 
 let cachedToken: TokenEntry | undefined = undefined;
 
-function b64url(obj: unknown): string {
-  return Buffer.from(JSON.stringify(obj)).toString("base64url");
-}
-
-function resolvePrivateKey(keyOrPath: string): string {
-  const trimmed = keyOrPath.trim();
-
-  if (trimmed.startsWith("-----BEGIN ")) {
-    return trimmed;
-  }
-
-  try {
-    return readFileSync(trimmed, "utf8");
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new ToolError(
-      `GitHub plugin privateKey is not PEM and could not be read as file path: ${message}`,
-    );
-  }
-}
-
-function generateJWT(appId: string, keyOrPath: string): string {
+async function generateJWT(
+  appId: string,
+  keyOrPath: string,
+  ctx: PluginToolContext,
+): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: "RS256" as const, typ: "JWT" };
   const payload = {
@@ -43,12 +23,40 @@ function generateJWT(appId: string, keyOrPath: string): string {
     iss: appId,
   };
 
-  const signingInput = `${b64url(header)}.${b64url(payload)}`;
-  const pem = resolvePrivateKey(keyOrPath);
-  const key = createPrivateKey(pem);
-  const signature = sign("sha256", Buffer.from(signingInput), key);
+  const encoder = new TextEncoder();
+  const signingInput = [
+    base64urlEncode(encoder.encode(JSON.stringify(header))),
+    base64urlEncode(encoder.encode(JSON.stringify(payload))),
+  ].join(".");
 
-  return `${signingInput}.${signature.toString("base64url")}`;
+  // Normalize the key via the runtime (handles PKCS#1 → PKCS#8 auto-detection).
+  const trimmed = keyOrPath.trim();
+  const normalized = await ctx.crypto.loadNormalizedKey(
+    trimmed.startsWith("-----BEGIN ") ? { data: trimmed } : { path: trimmed },
+  );
+
+  // Decode PEM to DER for Web Crypto import.
+  const keyDer = pemToDer(normalized.data);
+
+  // loadNormalizedKey returns "pkcs8" for private keys; signing requires private key.
+  if (normalized.format !== "pkcs8") {
+    throw new ToolError("GitHub plugin private key must be a private key");
+  }
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    keyDer as Uint8Array<ArrayBuffer>, // oxlint-disable-line typescript/no-unsafe-type-assertion
+    { hash: "SHA-256", name: "RSASSA-PKCS1-v1_5" },
+    false,
+    ["sign"],
+  );
+
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    encoder.encode(signingInput),
+  );
+
+  return `${signingInput}.${base64urlEncode(new Uint8Array(signature))}`;
 }
 
 export async function getInstallationToken(ctx: PluginToolContext): Promise<string> {
@@ -58,7 +66,7 @@ export async function getInstallationToken(ctx: PluginToolContext): Promise<stri
   }
 
   const config = await loadConfig(ctx);
-  const jwt = generateJWT(config.appId, config.privateKey);
+  const jwt = await generateJWT(config.appId, config.privateKey, ctx);
 
   const response = await ctx.net.fetch(
     `https://api.github.com/app/installations/${config.installationId}/access_tokens`,

--- a/packages/runtime/src/engine/index.ts
+++ b/packages/runtime/src/engine/index.ts
@@ -1,3 +1,7 @@
+import { createPrivateKey, createPublicKey } from "node:crypto";
+import { readFile, writeFile, mkdir, stat, readdir } from "node:fs/promises";
+import path from "node:path";
+
 import { KeyPoolManager } from "@cireilclaw/sdk";
 import * as vb from "valibot";
 
@@ -154,7 +158,93 @@ export async function runTurn(
     },
     conditions,
     createKeyPool: (keys, cooldownMs) => KeyPoolManager.getPool(keys, cooldownMs),
+    crypto: {
+      loadNormalizedKey: async (
+        opts: { path: string } | { data: string },
+      ): Promise<{ format: "pkcs8" | "spki"; data: string }> => {
+        let rawKey = "";
+        if ("path" in opts) {
+          const realPath = sandboxToReal(opts.path, agentSlug, sandboxConfig.mounts);
+          if (conditions !== undefined) {
+            checkConditionalAccess(opts.path, agentSlug, conditions, session);
+          }
+          rawKey = await readFile(realPath, "utf8");
+        } else {
+          rawKey = opts.data;
+        }
+
+        try {
+          const privateKey = createPrivateKey(rawKey);
+          return {
+            data: privateKey.export({ format: "pem", type: "pkcs8" }),
+            format: "pkcs8",
+          };
+        } catch {
+          // Not a private key.
+        }
+
+        const publicKey = createPublicKey(rawKey);
+        return {
+          data: publicKey.export({ format: "pem", type: "spki" }),
+          format: "spki",
+        };
+      },
+    },
     db: getDb(agentSlug),
+    fs: {
+      listDir: async (
+        sandboxPath: string,
+      ): Promise<{ name: string; isDirectory: boolean; isFile: boolean }[]> => {
+        const realPath = sandboxToReal(sandboxPath, agentSlug, sandboxConfig.mounts);
+        if (conditions !== undefined) {
+          checkConditionalAccess(sandboxPath, agentSlug, conditions, session);
+        }
+        const entries = await readdir(realPath, { withFileTypes: true });
+        return entries.map((entry) => ({
+          isDirectory: entry.isDirectory(),
+          isFile: entry.isFile(),
+          name: entry.name,
+        }));
+      },
+      readTextFile: async (sandboxPath: string): Promise<string> => {
+        const realPath = sandboxToReal(sandboxPath, agentSlug, sandboxConfig.mounts);
+        if (conditions !== undefined) {
+          checkConditionalAccess(sandboxPath, agentSlug, conditions, session);
+        }
+        return await readFile(realPath, "utf8");
+      },
+      stat: async (
+        sandboxPath: string,
+      ): Promise<{
+        ctimeMs: number;
+        isDirectory: boolean;
+        isFile: boolean;
+        mtimeMs: number;
+        size: number;
+      }> => {
+        const realPath = sandboxToReal(sandboxPath, agentSlug, sandboxConfig.mounts);
+        if (conditions !== undefined) {
+          checkConditionalAccess(sandboxPath, agentSlug, conditions, session);
+        }
+        const stats = await stat(realPath);
+        return {
+          ctimeMs: stats.ctimeMs,
+          isDirectory: stats.isDirectory(),
+          isFile: stats.isFile(),
+          mtimeMs: stats.mtimeMs,
+          size: stats.size,
+        };
+      },
+      writeTextFile: async (sandboxPath: string, content: string): Promise<void> => {
+        const realPath = sandboxToReal(sandboxPath, agentSlug, sandboxConfig.mounts);
+        checkMountWriteAccess(sandboxPath, sandboxConfig.mounts);
+        if (conditions !== undefined) {
+          checkConditionalAccess(sandboxPath, agentSlug, conditions, session);
+        }
+        await mkdir(path.dirname(realPath), { recursive: true });
+        await writeFile(realPath, content, "utf8");
+      },
+    },
     mounts: sandboxConfig.mounts,
     net: {
       fetch: globalThis.fetch.bind(globalThis),

--- a/packages/runtime/src/plugin/loader.ts
+++ b/packages/runtime/src/plugin/loader.ts
@@ -1,8 +1,9 @@
 /* oxlint-disable typescript/no-unsafe-type-assertion, typescript/promise-function-async
    -- RPC boundary: args arrive as unknown[] and are coerced via trust contract with worker.ts */
 
+import { createPrivateKey, createPublicKey } from "node:crypto";
 import { existsSync, realpathSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -316,6 +317,92 @@ class PluginProcess {
         checkConditionalAccess(sandboxPath as string, ctx.agentSlug, ctx.conditions, ctx.session);
       }
       return Promise.resolve(undefined);
+    });
+    this.rpc.handle("fs.readTextFile", async (args) => {
+      const [invocationId, sandboxPath] = args;
+      const ctx = this.requireCtx(invocationId);
+      const realPath = sandboxToReal(sandboxPath as string, ctx.agentSlug, ctx.mounts);
+      if (ctx.conditions !== undefined) {
+        checkConditionalAccess(sandboxPath as string, ctx.agentSlug, ctx.conditions, ctx.session);
+      }
+      return await readFile(realPath, "utf8");
+    });
+    this.rpc.handle("fs.writeTextFile", async (args) => {
+      const [invocationId, sandboxPath, content] = args;
+      const ctx = this.requireCtx(invocationId);
+      const realPath = sandboxToReal(sandboxPath as string, ctx.agentSlug, ctx.mounts);
+      checkMountWriteAccess(sandboxPath as string, ctx.mounts ?? []);
+      if (ctx.conditions !== undefined) {
+        checkConditionalAccess(sandboxPath as string, ctx.agentSlug, ctx.conditions, ctx.session);
+      }
+      await mkdir(path.dirname(realPath), { recursive: true });
+      await writeFile(realPath, content as string, "utf8");
+      return undefined;
+    });
+    this.rpc.handle("fs.stat", async (args) => {
+      const [invocationId, sandboxPath] = args;
+      const ctx = this.requireCtx(invocationId);
+      const realPath = sandboxToReal(sandboxPath as string, ctx.agentSlug, ctx.mounts);
+      if (ctx.conditions !== undefined) {
+        checkConditionalAccess(sandboxPath as string, ctx.agentSlug, ctx.conditions, ctx.session);
+      }
+      const stats = await stat(realPath);
+      return {
+        ctimeMs: stats.ctimeMs,
+        isDirectory: stats.isDirectory(),
+        isFile: stats.isFile(),
+        mtimeMs: stats.mtimeMs,
+        size: stats.size,
+      };
+    });
+    this.rpc.handle("fs.listDir", async (args) => {
+      const [invocationId, sandboxPath] = args;
+      const ctx = this.requireCtx(invocationId);
+      const realPath = sandboxToReal(sandboxPath as string, ctx.agentSlug, ctx.mounts);
+      if (ctx.conditions !== undefined) {
+        checkConditionalAccess(sandboxPath as string, ctx.agentSlug, ctx.conditions, ctx.session);
+      }
+      const entries = await readdir(realPath, { withFileTypes: true });
+      return entries.map((entry) => ({
+        isDirectory: entry.isDirectory(),
+        isFile: entry.isFile(),
+        name: entry.name,
+      }));
+    });
+    this.rpc.handle("crypto.loadNormalizedKey", async (args) => {
+      const [invocationId, opts] = args;
+      const ctx = this.requireCtx(invocationId);
+      const raw = opts as { path?: string; data?: string };
+
+      let rawKey = "";
+      if (typeof raw.path === "string") {
+        const realPath = sandboxToReal(raw.path, ctx.agentSlug, ctx.mounts);
+        if (ctx.conditions !== undefined) {
+          checkConditionalAccess(raw.path, ctx.agentSlug, ctx.conditions, ctx.session);
+        }
+        rawKey = await readFile(realPath, "utf8");
+      } else if (typeof raw.data === "string") {
+        rawKey = raw.data;
+      } else {
+        throw new TypeError("crypto.loadNormalizedKey requires either `path` or `data`");
+      }
+
+      // Try as private key (auto-detects PKCS#1, PKCS#8, SEC1).
+      try {
+        const key = createPrivateKey(rawKey);
+        return {
+          data: key.export({ format: "pem", type: "pkcs8" }),
+          format: "pkcs8",
+        };
+      } catch {
+        // Not a private key.
+      }
+
+      const pubKey = createPublicKey(rawKey);
+      return {
+        data: pubKey.export({ format: "pem", type: "spki" }),
+        format: "spki",
+      };
     });
   }
 }

--- a/packages/runtime/src/plugin/worker-main.ts
+++ b/packages/runtime/src/plugin/worker-main.ts
@@ -149,6 +149,30 @@ function buildCtx(rpc: RpcChannel, invocationId: string, data: CtxData): PluginT
     // to the runtime. Fine as long as each plugin owns its keys. If two plugins share a
     // key, failure tracking is per-worker and will drift.
     createKeyPool: (keys, cooldownMs): KeyPool => KeyPoolManager.getPool(keys, cooldownMs),
+    crypto: {
+      loadNormalizedKey: async (opts): Promise<{ format: "pkcs8" | "spki"; data: string }> =>
+        await rpc.call("crypto.loadNormalizedKey", [invocationId, opts]),
+    },
+    fs: {
+      listDir: async (
+        sandboxPath,
+      ): Promise<{ name: string; isDirectory: boolean; isFile: boolean }[]> =>
+        await rpc.call("fs.listDir", [invocationId, sandboxPath]),
+      readTextFile: async (sandboxPath): Promise<string> =>
+        await rpc.call("fs.readTextFile", [invocationId, sandboxPath]),
+      stat: async (
+        sandboxPath,
+      ): Promise<{
+        ctimeMs: number;
+        isDirectory: boolean;
+        isFile: boolean;
+        mtimeMs: number;
+        size: number;
+      }> => await rpc.call("fs.stat", [invocationId, sandboxPath]),
+      writeTextFile: async (sandboxPath, content): Promise<void> => {
+        await rpc.call("fs.writeTextFile", [invocationId, sandboxPath, content]);
+      },
+    },
     mounts: data.mounts,
     net: {
       fetch: globalThis.fetch.bind(globalThis),

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cireilclaw/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "files": [
     "src",

--- a/packages/sdk/src/encoding.ts
+++ b/packages/sdk/src/encoding.ts
@@ -1,0 +1,87 @@
+/**
+ * Strip PEM armor and base64-decode the body to DER bytes,
+ * detecting the key type from the PEM header.
+ */
+function pemToDerInner(pem: string): {
+  der: Uint8Array;
+  type: "privateKey" | "pkcs8" | "cert" | "spki";
+} {
+  const lines = pem.split("\n");
+  const bodyLines: string[] = [];
+  let inBody = false;
+  let type: "privateKey" | "pkcs8" | "cert" | "spki" = "pkcs8";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("-----BEGIN ")) {
+      inBody = true;
+      if (trimmed.includes("RSA PRIVATE KEY")) {
+        type = "privateKey";
+      } else if (trimmed.includes("CERTIFICATE")) {
+        type = "cert";
+      } else if (trimmed.includes("PUBLIC KEY")) {
+        type = "spki";
+      }
+      continue;
+    }
+    if (trimmed.startsWith("-----END ")) {
+      break;
+    }
+    if (inBody && trimmed.length > 0) {
+      bodyLines.push(trimmed);
+    }
+  }
+
+  const encoded = bodyLines.join("");
+  const binaryString = atob(encoded);
+  const result = new Uint8Array(binaryString.length);
+
+  for (let index = 0; index < binaryString.length; index++) {
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    result[index] = binaryString.codePointAt(index)!;
+  }
+
+  return { der: result, type };
+}
+
+/**
+ * Strip PEM armor and base64-decode the body to DER bytes.
+ * Handles PKCS#8, PKCS#1, SPKI, and "-----BEGIN CERTIFICATE-----" headers.
+ */
+function stripPem(pem: string): Uint8Array {
+  return pemToDerInner(pem).der;
+}
+
+/**
+ * Base64url-encode a byte array (no padding).
+ */
+function b64urlEncode(data: Uint8Array): string {
+  const codePoints: number[] = [];
+  for (const byte of data) {
+    codePoints.push(byte);
+  }
+  return btoa(String.fromCodePoint(...codePoints))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+/**
+ * Base64url-decode a string to bytes (tolerates missing padding).
+ */
+function b64urlDecode(str: string): Uint8Array {
+  // Restore standard base64
+  let base64 = str.replaceAll("-", "+").replaceAll("_", "/");
+  while (base64.length % 4 !== 0) {
+    base64 += "=";
+  }
+  const binaryString = atob(base64);
+  const result = new Uint8Array(binaryString.length);
+  for (let index = 0; index < binaryString.length; index++) {
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    result[index] = binaryString.codePointAt(index)!;
+  }
+  return result;
+}
+
+export { b64urlDecode as base64urlDecode, b64urlEncode as base64urlEncode, stripPem as pemToDer };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,14 +4,19 @@ export { KeyPool, KeyPoolManager } from "#key-pool.js";
 export type {
   BasicSession,
   ChannelResolution,
+  FsApi,
+  FsDirent,
+  FsStat,
   Mount,
   PluginToolContext,
   Tool,
   ToolDef,
   ToolErrorResult,
   ToolResult,
+  WebCryptoFormat,
 } from "#tool.js";
 export type { PluginSession } from "#session.js";
 export { ToolError } from "#errors.js";
 export { toWebp, toJpeg, scaleForAnthropic } from "#image.js";
+export { pemToDer, base64urlEncode, base64urlDecode } from "#encoding.js";
 export * as vb from "valibot";

--- a/packages/sdk/src/tool.ts
+++ b/packages/sdk/src/tool.ts
@@ -37,6 +37,37 @@ interface BasicSession {
   id(): string;
 }
 
+/**
+ * A key normalized for Web Crypto import.
+ * - `format: "pkcs8"` with the PEM string for private keys
+ * - `format: "spki"` with the PEM string for public keys
+ */
+interface WebCryptoFormat {
+  format: "pkcs8" | "spki";
+  data: string;
+}
+
+interface FsStat {
+  size: number;
+  isDirectory: boolean;
+  isFile: boolean;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+interface FsDirent {
+  name: string;
+  isDirectory: boolean;
+  isFile: boolean;
+}
+
+interface FsApi {
+  readTextFile(this: void, sandboxPath: string): Promise<string>;
+  writeTextFile(this: void, sandboxPath: string, content: string): Promise<void>;
+  stat(this: void, sandboxPath: string): Promise<FsStat>;
+  listDir(this: void, sandboxPath: string): Promise<FsDirent[]>;
+}
+
 interface PluginToolContext {
   session: BasicSession;
   agentSlug: string;
@@ -52,6 +83,19 @@ interface PluginToolContext {
     agentPlugin(this: void, name: string): Promise<Record<string, unknown> | undefined>;
   };
   createKeyPool(this: void, keys: string | string[], cooldownMs?: number): KeyPool;
+  crypto: {
+    /**
+     * Normalize a PEM/DER key to a Web-Crypto-compatible format.
+     *
+     * Accepts a sandbox path (read via ctx.fs) or an inline data string.
+     * Returns the key in PKCS#8 (private) or SPKI (public) PEM format,
+     * auto-detecting the input format (PKCS#1, PKCS#8, SEC1, SPKI…).
+     */
+    loadNormalizedKey(
+      this: void,
+      opts: { path: string } | { data: string },
+    ): Promise<WebCryptoFormat>;
+  };
   // Plugins should use ctx.net.fetch instead of the global fetch. This is the mediation point
   // for future isolation (worker/subprocess); today it's a passthrough.
   net: {
@@ -61,6 +105,7 @@ interface PluginToolContext {
   addImage(this: void, data: Uint8Array, mediaType: string): void;
   addVideo(this: void, data: Uint8Array, mediaType: string): void;
   addToolMessage(this: void, content: string): void;
+  fs: FsApi;
   paths: {
     resolve(this: void, sandboxPath: string): Promise<string>;
     checkWriteAccess(this: void, sandboxPath: string): Promise<void>;
@@ -75,10 +120,14 @@ interface ToolDef extends Tool {
 export type {
   BasicSession,
   ChannelResolution,
+  FsApi,
+  FsDirent,
+  FsStat,
   Mount,
   PluginToolContext,
   Tool,
   ToolDef,
   ToolErrorResult,
   ToolResult,
+  WebCryptoFormat,
 };

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -33,6 +33,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@cireilclaw/sdk": "^0.4.0"
+    "@cireilclaw/sdk": "^0.5.0"
   }
 }


### PR DESCRIPTION
Expands the surface area of what we (currently pretend to) isolate (so in the future we can actually do it) to a few new fields.

Filesystem, and critically due to the GitHub plugin, cryptography.
SDK + Plugins require a version bump due to this too. Publishing once PR is merged.