### PR TITLE
Assorted `tool_call_id` desync fixes

### DIFF
--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -41,6 +41,7 @@ import { sendDiscordWarningMessage } from "#channels/discord/warning-message.js"
 import { loadChannel, loadEngine } from "#config/index.js";
 import { saveSession } from "#db/sessions.js";
 import type { ImageContent, TextContent, VideoContent } from "#engine/content.js";
+import { cascadeRemoveToolResponses, getToolCallIds } from "#engine/history-validate.js";
 import type { Message } from "#engine/message.js";
 import type { ChannelHandler } from "#harness/channel-handler.js";
 import type { Harness } from "#harness/index.js";
@@ -1041,7 +1042,17 @@ async function handleMessageDelete(ctx: HandlerCtx, msg: PossiblyUncachedMessage
       return;
     }
 
+    const deletedMsg = session.history[entryIndex];
+    if (deletedMsg === undefined) {
+      return;
+    }
     session.history.splice(entryIndex, 1);
+    const toolCallIds = getToolCallIds(deletedMsg);
+    const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, entryIndex);
+    const totalRemoved = 1 + cascaded;
+    if (session.historyCursor > entryIndex) {
+      session.historyCursor = Math.max(entryIndex, session.historyCursor - totalRemoved);
+    }
 
     if (session.lastMessageId === msg.id) {
       const lastUserMsg = session.history.findLast((historyMsg) => historyMsg.id !== undefined);

--- a/packages/runtime/src/channels/discord.ts
+++ b/packages/runtime/src/channels/discord.ts
@@ -1044,18 +1044,24 @@ async function handleMessageDelete(ctx: HandlerCtx, msg: PossiblyUncachedMessage
 
     const deletedMsg = session.history[entryIndex];
     if (deletedMsg === undefined) {
-      return;
-    }
-    session.history.splice(entryIndex, 1);
-    const toolCallIds = getToolCallIds(deletedMsg);
-    const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, entryIndex);
-    const totalRemoved = 1 + cascaded;
-    if (session.historyCursor > entryIndex) {
-      session.historyCursor = Math.max(entryIndex, session.historyCursor - totalRemoved);
+      warning(
+        "History corruption: message found by findIndex but entry is undefined at index",
+        entryIndex,
+        colors.keyword(agentSlug),
+        colors.keyword(session.id()),
+      );
+    } else {
+      const toolCallIds = getToolCallIds(deletedMsg);
+      session.history.splice(entryIndex, 1);
+      const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, entryIndex);
+      const totalRemoved = 1 + cascaded;
+      if (session.historyCursor > entryIndex) {
+        session.historyCursor = Math.max(entryIndex, session.historyCursor - totalRemoved);
+      }
     }
 
     if (session.lastMessageId === msg.id) {
-      const lastUserMsg = session.history.findLast((historyMsg) => historyMsg.id !== undefined);
+      const lastUserMsg = session.history.findLast((historyEntry) => historyEntry.id !== undefined);
       session.lastMessageId = lastUserMsg?.id;
     }
 

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -7,6 +7,7 @@ import { ApplicationCommandTypes, MessageFlags } from "oceanic.js";
 
 import type { HandlerCtx } from "#channels/discord/handler-ctx.js";
 import { saveSession } from "#db/sessions.js";
+import { cascadeRemoveToolResponses, getToolCallIds } from "#engine/history-validate.js";
 import { DiscordSession } from "#harness/session.js";
 import { sanitizeError } from "#util/paths.js";
 
@@ -85,10 +86,17 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
         (entry) => entry.id === targetMsg.id || (entry.messageIds?.includes(targetMsg.id) ?? false),
       );
       if (msgIndex !== -1) {
-        if (session.historyCursor > msgIndex) {
-          session.historyCursor--;
+        const deletedMsg = session.history[msgIndex];
+        if (deletedMsg === undefined) {
+          return;
         }
+        const toolCallIds = getToolCallIds(deletedMsg);
         session.history.splice(msgIndex, 1);
+        const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, msgIndex);
+        const totalRemoved = 1 + cascaded;
+        if (session.historyCursor > msgIndex) {
+          session.historyCursor = Math.max(msgIndex, session.historyCursor - totalRemoved);
+        }
         session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
       }
       saveSession(ctx.agentSlug, session);

--- a/packages/runtime/src/channels/discord/delete-command.ts
+++ b/packages/runtime/src/channels/discord/delete-command.ts
@@ -9,6 +9,8 @@ import type { HandlerCtx } from "#channels/discord/handler-ctx.js";
 import { saveSession } from "#db/sessions.js";
 import { cascadeRemoveToolResponses, getToolCallIds } from "#engine/history-validate.js";
 import { DiscordSession } from "#harness/session.js";
+import colors from "#output/colors.js";
+import { warning } from "#output/log.js";
 import { sanitizeError } from "#util/paths.js";
 
 const definition: CreateApplicationCommandOptions = {
@@ -88,14 +90,20 @@ async function handle(interaction: CommandInteraction, ctx: HandlerCtx): Promise
       if (msgIndex !== -1) {
         const deletedMsg = session.history[msgIndex];
         if (deletedMsg === undefined) {
-          return;
-        }
-        const toolCallIds = getToolCallIds(deletedMsg);
-        session.history.splice(msgIndex, 1);
-        const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, msgIndex);
-        const totalRemoved = 1 + cascaded;
-        if (session.historyCursor > msgIndex) {
-          session.historyCursor = Math.max(msgIndex, session.historyCursor - totalRemoved);
+          warning(
+            "History corruption: message found by findIndex but entry is undefined at index",
+            msgIndex,
+            colors.keyword(ctx.agentSlug),
+            colors.keyword(session.id()),
+          );
+        } else {
+          const toolCallIds = getToolCallIds(deletedMsg);
+          session.history.splice(msgIndex, 1);
+          const cascaded = cascadeRemoveToolResponses(session.history, toolCallIds, msgIndex);
+          const totalRemoved = 1 + cascaded;
+          if (session.historyCursor > msgIndex) {
+            session.historyCursor = Math.max(msgIndex, session.historyCursor - totalRemoved);
+          }
         }
         session.lastMessageId = session.history.findLast((entry) => entry.id !== undefined)?.id;
       }

--- a/packages/runtime/src/db/sessions.ts
+++ b/packages/runtime/src/db/sessions.ts
@@ -10,6 +10,7 @@ import { getDb } from "#db/index.js";
 import { images, sessions, summaries as summariesTable } from "#db/schema.js";
 import type { Content, ImageContent, ImageRef, VideoContent, VideoRef } from "#engine/content.js";
 import { isImageRef, isVideoContent, isVideoRef } from "#engine/content.js";
+import { validateHistory } from "#engine/history-validate.js";
 import { isMessage } from "#engine/message.js";
 import type { AssistantContent, Message, UserContent } from "#engine/message.js";
 import type { Session, Summary } from "#harness/session.js";
@@ -82,8 +83,9 @@ function serializeHistory(
   }
 
   const persistable = history.filter((msg) => !("persist" in msg && msg.persist === false));
+  const validated = validateHistory(persistable);
 
-  const serialized = persistable.map((msg) => ({
+  const serialized = validated.map((msg) => ({
     ...msg,
     content: Array.isArray(msg.content)
       ? msg.content.map(serializeContent)
@@ -205,7 +207,7 @@ async function deserializeHistory(json: string, agentSlug: string): Promise<Mess
     }
   }
 
-  return messages;
+  return validateHistory(messages);
 }
 
 const LastContextWarningCursorSchema = vb.pipe(vb.number(), vb.integer(), vb.minValue(0));

--- a/packages/runtime/src/engine/history-validate.test.ts
+++ b/packages/runtime/src/engine/history-validate.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+
+import type { ToolCallContent } from "./content.js";
+import { cascadeRemoveToolResponses, getToolCallIds, validateHistory } from "./history-validate.js";
+import type { Message } from "./message.js";
+
+function assistantMsg(content: string, ids?: string[]): Message {
+  const toolCalls: ToolCallContent[] = ids
+    ? ids.map((id) => ({ id, input: {}, name: "test", type: "toolCall" }))
+    : [];
+  const blocks = toolCalls.length > 0 ? toolCalls : [{ content, type: "text" as const }];
+  const msg: Message = { content: blocks, role: "assistant" };
+  return msg;
+}
+
+function toolResponse(id: string): Message {
+  const msg: Message = {
+    content: { id, name: "test", output: { ok: true }, type: "toolResponse" as const },
+    role: "toolResponse",
+  };
+  return msg;
+}
+
+function userMsg(content: string): Message {
+  const msg: Message = { content: { content, type: "text" as const }, role: "user" };
+  return msg;
+}
+
+function systemMsg(content: string): Message {
+  const msg: Message = { content: { content, type: "text" as const }, role: "system" };
+  return msg;
+}
+
+describe("getToolCallIds", () => {
+  it("returns ids from assistant message with tool calls", () => {
+    const msg = assistantMsg("", ["call-1", "call-2"]);
+    expect(getToolCallIds(msg)).toEqual(["call-1", "call-2"]);
+  });
+
+  it("returns empty for assistant message without tool calls", () => {
+    const msg = assistantMsg("hello");
+    expect(getToolCallIds(msg)).toEqual([]);
+  });
+
+  it("returns empty for user message", () => {
+    const msg = userMsg("hi");
+    expect(getToolCallIds(msg)).toEqual([]);
+  });
+
+  it("returns empty for tool response message", () => {
+    const msg = toolResponse("call-1");
+    expect(getToolCallIds(msg)).toEqual([]);
+  });
+});
+
+describe("validateHistory", () => {
+  it("leaves well-formed history unchanged", () => {
+    const history: Message[] = [
+      userMsg("what is the weather"),
+      assistantMsg("", ["call-1"]),
+      toolResponse("call-1"),
+      assistantMsg("it is sunny"),
+    ];
+    const result = validateHistory(history);
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual(history[0]);
+    // assistant toolCall normalized from array to single object
+    expect(result[1]).toEqual({
+      content: { id: "call-1", input: {}, name: "test", type: "toolCall" },
+      role: "assistant",
+    });
+    expect(result[2]).toEqual(history[2]);
+    // assistant text normalized from array to single object
+    expect(result[3]).toEqual({
+      content: { content: "it is sunny", type: "text" },
+      role: "assistant",
+    });
+  });
+
+  it("removes orphaned tool response (no matching assistant)", () => {
+    const messages: Message[] = [userMsg("hi"), toolResponse("call-orphan"), assistantMsg("hello")];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(2);
+    expect(result[1]?.role).toBe("assistant");
+  });
+
+  it("strips orphaned toolCall block from assistant", () => {
+    const msg: Message = {
+      content: [
+        { content: "Let me check", type: "text" },
+        { id: "call-missing", input: {}, name: "read", type: "toolCall" },
+      ],
+      role: "assistant",
+    };
+    const messages: Message[] = [userMsg("find it"), msg];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(2);
+    const [, assistant] = result;
+    if (assistant === undefined) {
+      throw new Error("Expected result[1]");
+    }
+    expect(assistant.role).toBe("assistant");
+    const blocks = Array.isArray(assistant.content) ? assistant.content : [assistant.content];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.type).toBe("text");
+  });
+
+  it("removes assistant message that becomes empty after stripping", () => {
+    const messages: Message[] = [
+      userMsg("run tool"),
+      {
+        content: [{ id: "call-only", input: {}, name: "exec", type: "toolCall" }],
+        role: "assistant",
+      },
+    ];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe("user");
+  });
+
+  it("handles both orphan types simultaneously", () => {
+    const messages: Message[] = [
+      userMsg("a"),
+      {
+        content: [{ id: "call-orphan", input: {}, name: "exec", type: "toolCall" }],
+        role: "assistant",
+      },
+      toolResponse("call-orphan"),
+      toolResponse("call-nonexistent"),
+      userMsg("b"),
+    ];
+    const result = validateHistory(messages);
+    // toolResponse("call-nonexistent") removed; assistant with "call-orphan" stays
+    expect(result).toHaveLength(4);
+    expect(result[0]?.role).toBe("user");
+    expect(result[3]?.role).toBe("user");
+  });
+
+  it("removes orphaned toolResponse and orphan toolCall when no match", () => {
+    const messages: Message[] = [
+      userMsg("a"),
+      {
+        content: [{ id: "call-orphan", input: {}, name: "exec", type: "toolCall" }],
+        role: "assistant",
+      },
+      toolResponse("call-nonexistent"),
+      userMsg("b"),
+    ];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.role).toBe("user");
+    expect(result[1]?.role).toBe("user");
+  });
+
+  it("preserves toolCall with matching toolResponse", () => {
+    const messages: Message[] = [
+      userMsg("check"),
+      assistantMsg("", ["call-ok"]),
+      toolResponse("call-ok"),
+    ];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1]).toEqual({
+      content: { id: "call-ok", input: {}, name: "test", type: "toolCall" },
+      role: "assistant",
+    });
+    expect(result[2]).toEqual(messages[2]);
+  });
+
+  it("preserves toolCall among mixed blocks when response exists", () => {
+    const msg: Message = {
+      content: [
+        { content: "thinking...", type: "text" },
+        { id: "call-ok", input: {}, name: "read", type: "toolCall" },
+      ],
+      role: "assistant",
+    };
+    const messages: Message[] = [userMsg("go"), msg, toolResponse("call-ok")];
+    expect(validateHistory(messages)).toEqual(messages);
+  });
+
+  it("handles multiple toolCalls — some responded, some orphaned", () => {
+    const messages: Message[] = [
+      userMsg("multi"),
+      {
+        content: [
+          { id: "call-1", input: {}, name: "read", type: "toolCall" },
+          { id: "call-2", input: {}, name: "exec", type: "toolCall" },
+          { id: "call-3", input: {}, name: "search", type: "toolCall" },
+        ],
+        role: "assistant",
+      },
+      toolResponse("call-1"),
+      toolResponse("call-3"),
+    ];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(4);
+    const [, assistant] = result;
+    if (assistant === undefined) {
+      throw new Error("Expected result[1]");
+    }
+    const blocks = Array.isArray(assistant.content) ? assistant.content : [assistant.content];
+    const callIds = blocks
+      .filter((block) => block.type === "toolCall")
+      .map((block) => (block as { id: string }).id);
+    expect(callIds).toEqual(["call-1", "call-3"]);
+  });
+
+  it("leaves non-tool messages untouched", () => {
+    const messages: Message[] = [userMsg("hello"), systemMsg("system note"), assistantMsg("world")];
+    const result = validateHistory(messages);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1]).toEqual(messages[1]);
+    // assistant text normalized from array to single object
+    expect(result[2]).toEqual({
+      content: { content: "world", type: "text" },
+      role: "assistant",
+    });
+  });
+});
+
+describe("cascadeRemoveToolResponses", () => {
+  it("removes toolResponses matching removed tool call ids", () => {
+    const messages: Message[] = [
+      userMsg("a"),
+      assistantMsg("", ["call-1"]),
+      toolResponse("call-1"),
+      userMsg("b"),
+    ];
+    const removed = cascadeRemoveToolResponses(messages, ["call-1"], 1);
+    expect(removed).toBe(1);
+    expect(messages).toHaveLength(3);
+    expect(messages[0]?.role).toBe("user");
+    expect(messages[1]?.role).toBe("assistant");
+    expect(messages[2]?.role).toBe("user");
+  });
+
+  it("removes no toolResponses when no ids match", () => {
+    const messages: Message[] = [
+      userMsg("a"),
+      assistantMsg("", ["call-1"]),
+      toolResponse("call-1"),
+    ];
+    const removed = cascadeRemoveToolResponses(messages, ["call-other"], 1);
+    expect(removed).toBe(0);
+    expect(messages).toHaveLength(3);
+  });
+
+  it("removes multiple matching toolResponses from mixed history", () => {
+    const messages: Message[] = [
+      userMsg("a"),
+      assistantMsg("", ["call-1", "call-2"]),
+      toolResponse("call-1"),
+      toolResponse("call-2"),
+      assistantMsg("done"),
+    ];
+    const removed = cascadeRemoveToolResponses(messages, ["call-1", "call-2"], 1);
+    expect(removed).toBe(2);
+    expect(messages).toHaveLength(3);
+    expect(messages[2]?.role).toBe("assistant");
+  });
+
+  it("does not remove non-matching toolResponses", () => {
+    const messages: Message[] = [
+      assistantMsg("", ["call-a"]),
+      toolResponse("call-a"),
+      assistantMsg("", ["call-b"]),
+      toolResponse("call-b"),
+    ];
+    const removed = cascadeRemoveToolResponses(messages, ["call-a"], 1);
+    expect(removed).toBe(1);
+    expect(messages).toHaveLength(3);
+    expect(messages[1]?.role).toBe("assistant");
+    expect(messages[2]?.role).toBe("toolResponse");
+  });
+
+  it("returns 0 for empty ids array", () => {
+    const messages: Message[] = [userMsg("a"), toolResponse("call-1")];
+    const removed = cascadeRemoveToolResponses(messages, [], 0);
+    expect(removed).toBe(0);
+    expect(messages).toHaveLength(2);
+  });
+
+  it("scans only forward from fromIndex", () => {
+    const messages: Message[] = [
+      assistantMsg("", ["call-1"]),
+      toolResponse("call-1"),
+      assistantMsg("", ["call-2"]),
+      toolResponse("call-2"),
+    ];
+    // Start at index 2 — should only find call-2's response
+    const removed = cascadeRemoveToolResponses(messages, ["call-1", "call-2"], 2);
+    expect(removed).toBe(1);
+    expect(messages).toHaveLength(3);
+    expect(messages[0]?.role).toBe("assistant");
+    expect(messages[1]?.role).toBe("toolResponse");
+    expect(messages[2]?.role).toBe("assistant");
+  });
+});

--- a/packages/runtime/src/engine/history-validate.ts
+++ b/packages/runtime/src/engine/history-validate.ts
@@ -1,6 +1,5 @@
+import type { ToolCallContent } from "#engine/content.js";
 import type { Message } from "#engine/message.js";
-
-import type { ToolCallContent } from "./content.js";
 
 /**
  * Extract tool_call IDs from an assistant message.

--- a/packages/runtime/src/engine/history-validate.ts
+++ b/packages/runtime/src/engine/history-validate.ts
@@ -1,0 +1,110 @@
+import type { Message } from "#engine/message.js";
+
+import type { ToolCallContent } from "./content.js";
+
+/**
+ * Extract tool_call IDs from an assistant message.
+ * Returns an empty array for non-assistant messages or messages without tool calls.
+ */
+function getToolCallIds(msg: Message): string[] {
+  if (msg.role !== "assistant") {
+    return [];
+  }
+  const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+  return blocks
+    .filter((block): block is ToolCallContent => block.type === "toolCall")
+    .map((block) => block.id);
+}
+
+/**
+ * Validate and repair a message history for API invariants.
+ *
+ * Removes:
+ * - `toolResponse` messages whose `content.id` is not found in any preceding
+ *   (or subsequent) assistant message's `toolCall` blocks.
+ * - `toolCall` blocks from assistant messages that have no matching
+ *   `toolResponse` (keeps other content blocks).
+ * - Assistant messages that become empty after stripping orphaned `toolCall`
+ *   blocks.
+ */
+function validateHistory(history: Message[]): Message[] {
+  // Pass 1: Collect all tool_call_ids from all assistant messages.
+  const allToolCallIds = new Set<string>();
+  for (const msg of history) {
+    for (const id of getToolCallIds(msg)) {
+      allToolCallIds.add(id);
+    }
+  }
+
+  // Pass 2: Remove orphaned toolResponses (whose id doesn't match any tool_call).
+  const filtered: Message[] = [];
+  for (const msg of history) {
+    if (msg.role === "toolResponse" && !allToolCallIds.has(msg.content.id)) {
+      continue;
+    }
+    filtered.push(msg);
+  }
+
+  // Pass 3: Collect all tool_call_ids that have a matching toolResponse.
+  const respondedIds = new Set<string>();
+  for (const msg of filtered) {
+    if (msg.role === "toolResponse") {
+      respondedIds.add(msg.content.id);
+    }
+  }
+
+  // Pass 4: Strip orphaned toolCall blocks from assistant messages.
+  const result: Message[] = [];
+  for (const msg of filtered) {
+    if (msg.role !== "assistant") {
+      result.push(msg);
+      continue;
+    }
+    const blocks = Array.isArray(msg.content) ? msg.content : [msg.content];
+    const kept = blocks.filter((block) => block.type !== "toolCall" || respondedIds.has(block.id));
+    if (kept.length === 0) {
+      // Assistant message became empty — drop it entirely.
+      continue;
+    }
+    const single = kept.length === 1 ? kept[0] : undefined;
+    if (single === undefined) {
+      result.push({ ...msg, content: kept });
+    } else {
+      result.push({ ...msg, content: single });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * After a message has been removed from an in-memory history array, scan
+ * forward from `fromIndex` and remove any `toolResponse` messages whose
+ * `content.id` matches one of the `removedToolCallIds`.
+ *
+ * Mutates `history` in place (splice). Returns the number of cascaded
+ * removals so the caller can adjust cursors.
+ */
+function cascadeRemoveToolResponses(
+  history: Message[],
+  removedToolCallIds: string[],
+  fromIndex: number,
+): number {
+  if (removedToolCallIds.length === 0) {
+    return 0;
+  }
+  const idSet = new Set(removedToolCallIds);
+  let removed = 0;
+  for (let idx = fromIndex; idx < history.length; ) {
+    const msg = history[idx];
+    if (msg?.role === "toolResponse" && idSet.has(msg.content.id)) {
+      history.splice(idx, 1);
+      removed++;
+    } else {
+      idx++;
+    }
+  }
+  return removed;
+}
+
+export { cascadeRemoveToolResponses, getToolCallIds, validateHistory };


### PR DESCRIPTION
Should theoretically be a general fix for the problem too, not just a fix for the specific commands.

Fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Validation at Persistence Boundaries

The PR adds validation of message history at critical serialization boundaries. In `packages/runtime/src/db/sessions.ts`, `validateHistory` is called:

1. **Before persistence** (`serializeHistory`): The filtered persistable message list is validated before being serialized to JSON and written to disk. This prevents corrupted or malformed histories from being persisted.

2. **After deserialization** (`deserializeHistory`): Reconstructed message arrays are validated before being returned to consumers. This prevents corrupted persisted data from being loaded back into memory and used by the engine.

This dual-boundary validation is a **security and correctness improvement** as it ensures that the tool_call/tool_response invariant cannot be violated through:
- Incomplete cleanup operations (tool responses left orphaned when their corresponding tool calls are removed)
- Data corruption on disk
- Deserialization of previously-corrupted sessions

## Comprehensive History Repair

The `validateHistory` function performs a four-pass normalization that goes beyond simply removing orphaned entries:
- **Pass 1**: Collects all `toolCall` IDs present across the entire history
- **Pass 2**: Filters out orphaned `toolResponse` messages (those without a matching `toolCall`)
- **Pass 3**: Collects the remaining matched response IDs
- **Pass 4**: Strips `toolCall` blocks from assistant messages without corresponding responses and removes now-empty assistant messages

This multi-pass approach repairs histories that may have been corrupted through partial cleanup or direct manipulation, not just preventing new corruption.

## Limitations of the Cascading Deletion Approach

The in-place mutation approach via `cascadeRemoveToolResponses` (used in Discord message deletion handlers) removes tool responses forward from the deletion index only. This assumes tool responses always follow their tool calls. While this is the expected message ordering from the API, histories could theoretically become malformed if tool responses appear before their tool calls or in non-sequential positions. The validation layer catches these cases during persistence/deserialization, but the cascading deletion alone does not guard against all possible corruption patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->