### PR TITLE
Improve frontmatter persistence across `str-replace`/`write`

### DIFF
--- a/packages/runtime/src/engine/tools/str-replace.test.ts
+++ b/packages/runtime/src/engine/tools/str-replace.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { strReplace } from "#engine/tools/str-replace.js";
+import type { ToolContext } from "#engine/tools/tool-def.js";
+
+const mockFs = {
+  existsSync: vi.fn(),
+};
+
+const mockFsPromises = {
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+};
+
+vi.mock("node:fs", () => ({
+  existsSync: (...args: unknown[]): unknown => mockFs.existsSync(...args),
+  realpathSync: (path: string): string => path,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: (...args: unknown[]): unknown => mockFsPromises.readFile(...args),
+  writeFile: (...args: unknown[]): unknown => mockFsPromises.writeFile(...args),
+}));
+
+vi.stubEnv("HOME", "/home/test");
+
+function makeToolContext(): ToolContext {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return {
+    paths: {
+      checkAccess: vi.fn().mockResolvedValue(undefined),
+      checkConditionalAccess: vi.fn().mockResolvedValue(undefined),
+      checkWriteAccess: vi.fn().mockResolvedValue(undefined),
+      resolve: vi
+        .fn()
+        .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/blocks/person.md"),
+    },
+    session: {
+      activeFileSections: new Map(),
+    },
+  } as unknown as ToolContext;
+}
+
+describe("str-replace frontmatter preservation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("replaces text in body only, preserving block frontmatter", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(
+      '+++\ndescription="Personality"\n+++\nHello, my name is Bob.\nI like apples.',
+    );
+
+    const ctx = makeToolContext();
+    const result = await strReplace.execute(
+      { new_text: "Alice", old_text: "Bob", path: "/blocks/person.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      '+++\ndescription="Personality"\n+++\nHello, my name is Alice.\nI like apples.',
+      "utf8",
+    );
+  });
+
+  it("replaces text in body only, preserving skill frontmatter", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(
+      "---\nname: my-skill\ndescription: A skill\n---\nOld body text here",
+    );
+
+    const ctx = makeToolContext();
+    const result = await strReplace.execute(
+      { new_text: "New body", old_text: "Old body", path: "/skills/my-skill/SKILL.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "---\nname: my-skill\ndescription: A skill\n---\nNew body text here",
+      "utf8",
+    );
+  });
+
+  it("does NOT match text inside frontmatter (only searches body)", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(
+      '+++\ndescription="Personality"\n+++\nBody content here.',
+    );
+
+    const ctx = makeToolContext();
+    // "Personality" appears in the frontmatter but not the body
+    await expect(
+      strReplace.execute(
+        { new_text: "New description", old_text: "Personality", path: "/blocks/person.md" },
+        ctx,
+      ),
+    ).rejects.toThrow("does not contain old_text");
+  });
+
+  it("searches full content for non-block/skill paths (no frontmatter isolation)", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue("The quick brown fox");
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi.fn().mockResolvedValue("/workspace/notes.txt");
+    const result = await strReplace.execute(
+      { new_text: "red", old_text: "brown", path: "/workspace/notes.txt" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "The quick red fox",
+      "utf8",
+    );
+  });
+
+  it("returns context lines with correct positions accounting for frontmatter offset", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(
+      '+++\ndescription="Personality"\n+++\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5',
+    );
+
+    const ctx = makeToolContext();
+    const result = await strReplace.execute(
+      { new_text: "Changed line", old_text: "Line 3", path: "/blocks/person.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(result["context"]).toContain("Changed line");
+    // Should show surrounding context from full file
+    expect(result["context"]).toContain("Line 2");
+    expect(result["context"]).toContain("Line 4");
+    // Frontmatter lines should not appear in context (they're before the replacement)
+    expect(result["context"]).not.toContain("+++");
+  });
+
+  it("throws when file does not exist", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const ctx = makeToolContext();
+    await expect(
+      strReplace.execute(
+        { new_text: "nothing", old_text: "anything", path: "/blocks/person.md" },
+        ctx,
+      ),
+    ).rejects.toThrow("does not exist");
+  });
+});

--- a/packages/runtime/src/engine/tools/str-replace.test.ts
+++ b/packages/runtime/src/engine/tools/str-replace.test.ts
@@ -153,4 +153,34 @@ describe("str-replace frontmatter preservation", () => {
       ),
     ).rejects.toThrow("does not exist");
   });
+
+  it("throws when existing block frontmatter has invalid schema", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    // TOML syntax is valid but `description` field is missing
+    mockFsPromises.readFile.mockResolvedValue("+++\nother_field=42\n+++\nBody content here.");
+
+    const ctx = makeToolContext();
+    await expect(
+      strReplace.execute(
+        { new_text: "Updated body", old_text: "Body content", path: "/blocks/person.md" },
+        ctx,
+      ),
+    ).rejects.toThrow("Invalid frontmatter");
+  });
+
+  it("throws when existing skill frontmatter has invalid schema (missing name)", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue("---\ndescription: A skill\n---\nOld body text here");
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi
+      .fn()
+      .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/skills/my-skill/SKILL.md");
+    await expect(
+      strReplace.execute(
+        { new_text: "New body", old_text: "Old body", path: "/skills/my-skill/SKILL.md" },
+        ctx,
+      ),
+    ).rejects.toThrow("Invalid frontmatter");
+  });
 });

--- a/packages/runtime/src/engine/tools/str-replace.ts
+++ b/packages/runtime/src/engine/tools/str-replace.ts
@@ -5,6 +5,7 @@ import * as vb from "valibot";
 
 import { ToolError } from "#engine/errors.js";
 import type { ToolContext, ToolDef } from "#engine/tools/tool-def.js";
+import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
 
 const Schema = vb.strictObject({
   new_text: vb.pipe(
@@ -32,8 +33,9 @@ export const strReplace: ToolDef = {
   description:
     "Find and replace exactly one occurrence of a literal string in an existing file.\n\n" +
     "`old_text` must be non-empty; `new_text` may be empty to delete. The match is exact — whitespace, indentation, and newlines all matter. On success, returns a few lines of context around the replacement.\n\n" +
+    "For files under /blocks/ and /skills/, search happens within the body only — the required frontmatter is transparently preserved and never matched or modified.\n\n" +
     "Error conditions:\n" +
-    "- `old_text` not found in the file → include more surrounding context to verify your match.\n" +
+    "- `old_text` not found in the body → include more surrounding context to verify your match.\n" +
     "- `old_text` found more than once → include additional surrounding lines to disambiguate.\n\n" +
     "Tip: Use `read` or `open-file` first to see the current file contents and craft an accurate match.\n\n" +
     "When NOT to use:\n" +
@@ -57,14 +59,29 @@ export const strReplace: ToolDef = {
 
     const content = await readFile(path, "utf8");
 
-    if (!content.includes(data.old_text)) {
+    // For files with required frontmatter (blocks, skills), extract the frontmatter
+    // and search/replace within the body only. The frontmatter is transparently
+    // preserved so the agent never accidentally corrupts it.
+    let searchContent = content;
+    let frontmatter: string | undefined = undefined;
+
+    if (requiresFrontmatter(data.path)) {
+      const split = splitFrontmatter(content, data.path.startsWith("/blocks/"));
+      if (split !== undefined) {
+        // oxlint-disable-next-line prefer-destructuring
+        frontmatter = split.frontmatter;
+        searchContent = split.body;
+      }
+    }
+
+    if (!searchContent.includes(data.old_text)) {
       throw new ToolError(`File does not contain old_text`);
     }
 
     let instances = 0;
     let idx: number | undefined = undefined;
 
-    while ((idx = content.indexOf(data.old_text, idx)) !== -1) {
+    while ((idx = searchContent.indexOf(data.old_text, idx)) !== -1) {
       instances++;
       idx += data.old_text.length;
     }
@@ -76,13 +93,19 @@ export const strReplace: ToolDef = {
       );
     }
 
-    const newContent = content.replace(data.old_text, () => data.new_text);
+    const newContent =
+      frontmatter === undefined
+        ? content.replace(data.old_text, () => data.new_text)
+        : frontmatter + searchContent.replace(data.old_text, () => data.new_text);
     await writeFile(path, newContent, "utf8");
 
     // Invalidate section cache — file content changed
     ctx.session.activeFileSections.delete(data.path);
 
-    const oldTextPos = content.indexOf(data.old_text);
+    const oldTextPos =
+      frontmatter === undefined
+        ? content.indexOf(data.old_text)
+        : frontmatter.length + searchContent.indexOf(data.old_text);
     const lineIndex = newContent.slice(0, oldTextPos).split("\n").length;
     const contextLines = 2;
     const newLines = newContent.split("\n");

--- a/packages/runtime/src/engine/tools/str-replace.ts
+++ b/packages/runtime/src/engine/tools/str-replace.ts
@@ -5,7 +5,7 @@ import * as vb from "valibot";
 
 import { ToolError } from "#engine/errors.js";
 import type { ToolContext, ToolDef } from "#engine/tools/tool-def.js";
-import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
+import { requiresFrontmatter, splitFrontmatter, validateFrontmatter } from "#util/frontmatter.js";
 
 const Schema = vb.strictObject({
   new_text: vb.pipe(
@@ -68,9 +68,7 @@ export const strReplace: ToolDef = {
     if (requiresFrontmatter(data.path)) {
       const split = splitFrontmatter(content, data.path.startsWith("/blocks/"));
       if (split !== undefined) {
-        // oxlint-disable-next-line prefer-destructuring
-        frontmatter = split.frontmatter;
-        searchContent = split.body;
+        ({ frontmatter, body: searchContent } = split);
       }
     }
 
@@ -97,6 +95,13 @@ export const strReplace: ToolDef = {
       frontmatter === undefined
         ? content.replace(data.old_text, () => data.new_text)
         : frontmatter + searchContent.replace(data.old_text, () => data.new_text);
+
+    // Validate preserved frontmatter before writing — catches pre-existing
+    // corruption so the agent gets immediate feedback instead of a load failure later.
+    if (frontmatter !== undefined) {
+      validateFrontmatter(frontmatter, data.path.startsWith("/blocks/"));
+    }
+
     await writeFile(path, newContent, "utf8");
 
     // Invalidate section cache — file content changed

--- a/packages/runtime/src/engine/tools/write.test.ts
+++ b/packages/runtime/src/engine/tools/write.test.ts
@@ -166,4 +166,72 @@ describe("write tool frontmatter preservation", () => {
     // File exists but has no valid frontmatter — write new content as-is
     expect(mockFsPromises.writeFile).toHaveBeenCalledWith(expect.any(String), "New body", "utf8");
   });
+
+  it("throws when existing block frontmatter has invalid schema", async () => {
+    const existingContent = "+++\nother_field=42\n+++\nOriginal body";
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(existingContent);
+
+    const ctx = makeToolContext();
+    await expect(
+      write.execute({ content: "New body", path: "/blocks/person.md" }, ctx),
+    ).rejects.toThrow("Invalid frontmatter");
+    // writeFile should not be called — validation fails before writing
+    expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("throws when existing skill frontmatter has invalid schema (missing name)", async () => {
+    const existingContent = "---\ndescription: A skill\n---\nOriginal body";
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(existingContent);
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi
+      .fn()
+      .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/skills/my-skill/SKILL.md");
+    await expect(
+      write.execute({ content: "New body", path: "/skills/my-skill/SKILL.md" }, ctx),
+    ).rejects.toThrow("Invalid frontmatter");
+    expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("throws when agent provides invalid frontmatter for a new block file", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi
+      .fn()
+      .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/blocks/newblock.md");
+    await expect(
+      write.execute(
+        {
+          content: "+++\nnot-valid-toml-[[[\n+++\nNew body",
+          path: "/blocks/newblock.md",
+        },
+        ctx,
+      ),
+    ).rejects.toThrow("Invalid frontmatter");
+    expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("allows new block file without frontmatter (no validation for agent content without delimiters)", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi
+      .fn()
+      .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/blocks/newblock.md");
+    const result = await write.execute(
+      { content: "Just body text, no frontmatter", path: "/blocks/newblock.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    // The write is allowed through even though loading will fail — preserves existing behavior
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "Just body text, no frontmatter",
+      "utf8",
+    );
+  });
 });

--- a/packages/runtime/src/engine/tools/write.test.ts
+++ b/packages/runtime/src/engine/tools/write.test.ts
@@ -1,7 +1,47 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ToolContext } from "#engine/tools/tool-def.js";
 import { write } from "#engine/tools/write.js";
+
+const mockFs = {
+  existsSync: vi.fn(),
+};
+
+const mockFsPromises = {
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+};
+
+vi.mock("node:fs", () => ({
+  existsSync: (...args: unknown[]): unknown => mockFs.existsSync(...args),
+  realpathSync: (path: string): string => path,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: (...args: unknown[]): unknown => mockFsPromises.mkdir(...args),
+  readFile: (...args: unknown[]): unknown => mockFsPromises.readFile(...args),
+  writeFile: (...args: unknown[]): unknown => mockFsPromises.writeFile(...args),
+}));
+
+vi.stubEnv("HOME", "/home/test");
+
+function makeToolContext(): ToolContext {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return {
+    paths: {
+      checkAccess: vi.fn().mockResolvedValue(undefined),
+      checkConditionalAccess: vi.fn().mockResolvedValue(undefined),
+      checkWriteAccess: vi.fn().mockResolvedValue(undefined),
+      resolve: vi
+        .fn()
+        .mockResolvedValue("/home/test/.cireilclaw/agents/testagent/blocks/person.md"),
+    },
+    session: {
+      activeFileSections: new Map(),
+    },
+  } as unknown as ToolContext;
+}
 
 describe("write tool schema", () => {
   it("rejects the /blocks directory as a file target", async () => {
@@ -9,5 +49,121 @@ describe("write tool schema", () => {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       write.execute({ content: "", path: "/blocks" }, {} as ToolContext),
     ).rejects.toThrow("Files in /blocks/ must end with .md extension");
+  });
+});
+
+describe("write tool frontmatter preservation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves existing frontmatter when new content lacks it (blocks)", async () => {
+    const existingContent = '+++\ndescription="My personality"\n+++\nOriginal body content';
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(existingContent);
+
+    const ctx = makeToolContext();
+    const result = await write.execute(
+      { content: "New body content", path: "/blocks/person.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      '+++\ndescription="My personality"\n+++\nNew body content',
+      "utf8",
+    );
+  });
+
+  it("preserves existing frontmatter when new content lacks it (skills)", async () => {
+    const existingContent = "---\nname: my-skill\ndescription: A skill\n---\nOriginal body";
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(existingContent);
+
+    const ctx = makeToolContext();
+    const result = await write.execute(
+      { content: "New body content", path: "/skills/my-skill/SKILL.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "---\nname: my-skill\ndescription: A skill\n---\nNew body content",
+      "utf8",
+    );
+  });
+
+  it("does NOT prepend frontmatter when new content already includes it", async () => {
+    const existingContent = '+++\ndescription="Old desc"\n+++\nOld body';
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue(existingContent);
+
+    const ctx = makeToolContext();
+    const result = await write.execute(
+      {
+        content: '+++\ndescription="New desc"\n+++\nNew body',
+        path: "/blocks/person.md",
+      },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    // Should use the new content as-is (agent explicitly provided frontmatter)
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      '+++\ndescription="New desc"\n+++\nNew body',
+      "utf8",
+    );
+  });
+
+  it("does NOT prepend frontmatter when file is new (doesn't exist yet)", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const ctx = makeToolContext();
+    const result = await write.execute(
+      { content: "Fresh body content", path: "/blocks/person.md" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    // New file, no existing frontmatter to preserve — write content as-is
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "Fresh body content",
+      "utf8",
+    );
+  });
+
+  it("does NOT preserve frontmatter for non-block/skill paths", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue("Some content");
+
+    const ctx = makeToolContext();
+    ctx.paths.resolve = vi.fn().mockResolvedValue("/some/other/path.txt");
+    const result = await write.execute(
+      { content: "New content", path: "/workspace/notes.txt" },
+      ctx,
+    );
+
+    expect(result["success"]).toBe(true);
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "New content",
+      "utf8",
+    );
+  });
+
+  it("handles existing file without valid frontmatter gracefully", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFsPromises.readFile.mockResolvedValue("No frontmatter here");
+
+    const ctx = makeToolContext();
+    const result = await write.execute({ content: "New body", path: "/blocks/person.md" }, ctx);
+
+    expect(result["success"]).toBe(true);
+    // File exists but has no valid frontmatter — write new content as-is
+    expect(mockFsPromises.writeFile).toHaveBeenCalledWith(expect.any(String), "New body", "utf8");
   });
 });

--- a/packages/runtime/src/engine/tools/write.ts
+++ b/packages/runtime/src/engine/tools/write.ts
@@ -1,9 +1,11 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import * as vb from "valibot";
 
 import type { ToolContext, ToolDef } from "#engine/tools/tool-def.js";
+import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
 
 const Schema = vb.strictObject({
   content: vb.pipe(
@@ -36,6 +38,7 @@ export const write: ToolDef = {
     "Constraints:\n" +
     "- Files under /blocks/ must have a .md extension.\n" +
     "- Allowed path roots: /workspace/, /memories/, /blocks/, /skills/.\n" +
+    "- For existing files under /blocks/ and /skills/, the existing frontmatter is auto-preserved when the provided content does not include frontmatter.\n" +
     "Note that paths used here *must* be absolute.\n\n" +
     "When to use:\n" +
     "- Creating new files from scratch.\n" +
@@ -49,8 +52,25 @@ export const write: ToolDef = {
     await ctx.paths.checkConditionalAccess(data.path);
     await ctx.paths.checkWriteAccess(data.path);
 
+    let { content } = data;
+
+    // When overwriting an existing block/skill file that requires frontmatter,
+    // preserve the existing frontmatter if the new content doesn't include it.
+    if (requiresFrontmatter(data.path) && existsSync(realPath)) {
+      const existing = await readFile(realPath, "utf8");
+      const isBlock = data.path.startsWith("/blocks/");
+      const split = splitFrontmatter(existing, isBlock);
+      if (split !== undefined) {
+        const { frontmatter } = split;
+        const delim = isBlock ? "+++" : "---";
+        if (!data.content.startsWith(delim)) {
+          content = frontmatter + data.content;
+        }
+      }
+    }
+
     await mkdir(path.dirname(realPath), { recursive: true });
-    await writeFile(realPath, data.content, "utf8");
+    await writeFile(realPath, content, "utf8");
 
     // Invalidate section cache — file content changed
     ctx.session.activeFileSections.delete(data.path);

--- a/packages/runtime/src/engine/tools/write.ts
+++ b/packages/runtime/src/engine/tools/write.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import * as vb from "valibot";
 
 import type { ToolContext, ToolDef } from "#engine/tools/tool-def.js";
-import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
+import { requiresFrontmatter, splitFrontmatter, validateFrontmatter } from "#util/frontmatter.js";
 
 const Schema = vb.strictObject({
   content: vb.pipe(
@@ -61,11 +61,22 @@ export const write: ToolDef = {
       const isBlock = data.path.startsWith("/blocks/");
       const split = splitFrontmatter(existing, isBlock);
       if (split !== undefined) {
+        // Validate preserved frontmatter before writing — catches pre-existing
+        // corruption so the agent gets immediate feedback instead of a load failure later.
+        validateFrontmatter(split.frontmatter, isBlock);
+
         const { frontmatter } = split;
         const delim = isBlock ? "+++" : "---";
         if (!data.content.startsWith(delim)) {
           content = frontmatter + data.content;
         }
+      }
+    } else if (requiresFrontmatter(data.path) && !existsSync(realPath)) {
+      // New block/skill file — validate the agent-provided frontmatter immediately.
+      const isBlock = data.path.startsWith("/blocks/");
+      const delim = isBlock ? "+++" : "---";
+      if (data.content.startsWith(delim)) {
+        validateFrontmatter(data.content, isBlock);
       }
     }
 

--- a/packages/runtime/src/util/frontmatter.test.ts
+++ b/packages/runtime/src/util/frontmatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
+import { requiresFrontmatter, splitFrontmatter, validateFrontmatter } from "#util/frontmatter.js";
 
 describe("requiresFrontmatter", () => {
   it("returns true for /blocks/ paths", () => {
@@ -90,6 +90,96 @@ describe("splitFrontmatter", () => {
 
     it("returns undefined when frontmatter has no closing ---", () => {
       expect(splitFrontmatter("---\nname: no-close", false)).toBeUndefined();
+    });
+  });
+
+  describe("validateFrontmatter", () => {
+    describe("blocks (TOML)", () => {
+      it("passes for valid TOML frontmatter", () => {
+        expect(() => {
+          validateFrontmatter('+++\ndescription="My block"\n+++\n', true);
+        }).not.toThrow();
+      });
+
+      it("passes for minimal valid TOML (empty description)", () => {
+        expect(() => {
+          validateFrontmatter('+++\ndescription=""\n+++\n', true);
+        }).not.toThrow();
+      });
+
+      it("throws for missing opening +++.+.", () => {
+        expect(() => {
+          validateFrontmatter('description="no delims"\n', true);
+        }).toThrow("Invalid frontmatter: expected file to start with '+++'");
+      });
+
+      it("throws for missing closing +++.+.", () => {
+        expect(() => {
+          validateFrontmatter('+++\ndescription="no close"', true);
+        }).toThrow("Invalid frontmatter: missing closing '+++'");
+      });
+
+      it("throws for invalid TOML syntax", () => {
+        expect(() => {
+          validateFrontmatter("+++\nnot-valid-toml-[[[\n+++\n", true);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+
+      it("throws when description field is missing", () => {
+        expect(() => {
+          validateFrontmatter("+++\nother=42\n+++\n", true);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+
+      it("throws when description has wrong type", () => {
+        expect(() => {
+          validateFrontmatter("+++\ndescription=42\n+++\n", true);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+    });
+
+    describe("skills (YAML)", () => {
+      it("passes for valid YAML frontmatter", () => {
+        expect(() => {
+          validateFrontmatter("---\nname: my-skill\ndescription: A test skill\n---\n", false);
+        }).not.toThrow();
+      });
+
+      it("throws for missing opening ---", () => {
+        expect(() => {
+          validateFrontmatter("name: my-skill\ndescription: A test\n", false);
+        }).toThrow("Invalid frontmatter: expected file to start with '---'");
+      });
+
+      it("throws for missing closing ---", () => {
+        expect(() => {
+          validateFrontmatter("---\nname: my-skill\ndescription: A test", false);
+        }).toThrow("Invalid frontmatter: missing closing '---'");
+      });
+
+      it("throws when name field is missing", () => {
+        expect(() => {
+          validateFrontmatter("---\ndescription: A test skill\n---\n", false);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+
+      it("throws when description field is missing", () => {
+        expect(() => {
+          validateFrontmatter("---\nname: my-skill\n---\n", false);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+
+      it("throws when name is empty", () => {
+        expect(() => {
+          validateFrontmatter('---\nname: ""\ndescription: A test skill\n---\n', false);
+        }).toThrow(/Invalid frontmatter/u);
+      });
+
+      it("throws when description is empty", () => {
+        expect(() => {
+          validateFrontmatter('---\nname: my-skill\ndescription: ""\n---\n', false);
+        }).toThrow(/Invalid frontmatter/u);
+      });
     });
   });
 });

--- a/packages/runtime/src/util/frontmatter.test.ts
+++ b/packages/runtime/src/util/frontmatter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { requiresFrontmatter, splitFrontmatter } from "#util/frontmatter.js";
+
+describe("requiresFrontmatter", () => {
+  it("returns true for /blocks/ paths", () => {
+    expect(requiresFrontmatter("/blocks/person.md")).toBe(true);
+    expect(requiresFrontmatter("/blocks/identity.md")).toBe(true);
+    expect(requiresFrontmatter("/blocks/conditional/nsfw.md")).toBe(true);
+    expect(requiresFrontmatter("/blocks/foo/bar/baz.md")).toBe(true);
+  });
+
+  it("returns true for /skills/**/SKILL.md paths", () => {
+    expect(requiresFrontmatter("/skills/my-skill/SKILL.md")).toBe(true);
+    expect(requiresFrontmatter("/skills/coding/SKILL.md")).toBe(true);
+  });
+
+  it("returns false for non-SKILL.md files under /skills/", () => {
+    expect(requiresFrontmatter("/skills/coding/README.md")).toBe(false);
+    expect(requiresFrontmatter("/skills/my-skill/notes.txt")).toBe(false);
+  });
+
+  it("returns false for other paths", () => {
+    expect(requiresFrontmatter("/workspace/main.ts")).toBe(false);
+    expect(requiresFrontmatter("/memories/note.md")).toBe(false);
+    expect(requiresFrontmatter("/tasks/HEARTBEAT.md")).toBe(false);
+    expect(requiresFrontmatter("/some/other/path.txt")).toBe(false);
+  });
+});
+
+function expectFrontmatter(input: string, isBlock: boolean): { body: string; frontmatter: string } {
+  const result = splitFrontmatter(input, isBlock);
+  if (result === undefined) {
+    throw new Error("Expected frontmatter to be defined");
+  }
+  return result;
+}
+
+describe("splitFrontmatter", () => {
+  describe("blocks (TOML, +++ delimiter)", () => {
+    it("extracts TOML frontmatter and body", () => {
+      const { body, frontmatter } = expectFrontmatter(
+        '+++\ndescription="Personality"\n+++\nThis is the body.',
+        true,
+      );
+      expect(frontmatter).toBe('+++\ndescription="Personality"\n+++\n');
+      expect(body).toBe("This is the body.");
+    });
+
+    it("handles multi-line frontmatter", () => {
+      const { body, frontmatter } = expectFrontmatter(
+        '+++\ndescription="My block"\nextra=42\n+++\nbody line 1\nbody line 2',
+        true,
+      );
+      expect(frontmatter).toBe('+++\ndescription="My block"\nextra=42\n+++\n');
+      expect(body).toBe("body line 1\nbody line 2");
+    });
+
+    it("handles body without trailing newline", () => {
+      const { body, frontmatter } = expectFrontmatter(
+        '+++\ndescription="test"\n+++\njust a body',
+        true,
+      );
+      expect(frontmatter).toBe('+++\ndescription="test"\n+++\n');
+      expect(body).toBe("just a body");
+    });
+
+    it("returns undefined when file doesn't start with +++", () => {
+      expect(splitFrontmatter("no frontmatter here", true)).toBeUndefined();
+    });
+
+    it("returns undefined when frontmatter has no closing +++", () => {
+      expect(splitFrontmatter('+++\ndescription="no close', true)).toBeUndefined();
+    });
+  });
+
+  describe("skills (YAML, --- delimiter)", () => {
+    it("extracts YAML frontmatter and body", () => {
+      const { body, frontmatter } = expectFrontmatter(
+        "---\nname: my-skill\ndescription: A skill\n---\nbody content here",
+        false,
+      );
+      expect(frontmatter).toBe("---\nname: my-skill\ndescription: A skill\n---\n");
+      expect(body).toBe("body content here");
+    });
+
+    it("returns undefined when file doesn't start with ---", () => {
+      expect(splitFrontmatter("no frontmatter here", false)).toBeUndefined();
+    });
+
+    it("returns undefined when frontmatter has no closing ---", () => {
+      expect(splitFrontmatter("---\nname: no-close", false)).toBeUndefined();
+    });
+  });
+});

--- a/packages/runtime/src/util/frontmatter.ts
+++ b/packages/runtime/src/util/frontmatter.ts
@@ -1,0 +1,58 @@
+/**
+ * Utility for preserving frontmatter in block/skill files during write and str-replace operations.
+ *
+ * Block files use TOML frontmatter delimited by `+++...+++`.
+ * Skill files use YAML frontmatter delimited by `---...---`.
+ * In both cases the frontmatter is REQUIRED — the loading code throws if it's missing or malformed.
+ */
+
+/**
+ * Returns true when a sandbox path refers to a file type that requires frontmatter.
+ * Block files: /blocks/ (any .md)
+ * Skill files: /skills/ (only SKILL.md)
+ */
+function requiresFrontmatter(sandboxPath: string): boolean {
+  if (sandboxPath.startsWith("/blocks/")) {
+    return true;
+  }
+  if (sandboxPath.startsWith("/skills/") && sandboxPath.endsWith("/SKILL.md")) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Splits file content into frontmatter (delimiter + content + closing delimiter + trailing newline)
+ * Returns undefined when the content doesn't have valid frontmatter for the file type.
+ *
+ * Matches the parsing logic in util/load.ts (`parseBlockFrontmatter` and the inline skill parser).
+ */
+function splitFrontmatter(
+  content: string,
+  isBlock: boolean,
+): { body: string; frontmatter: string } | undefined {
+  const delim = isBlock ? "+++" : "---";
+
+  if (!content.startsWith(delim)) {
+    return undefined;
+  }
+
+  const closingIdx = content.indexOf(delim, delim.length);
+  if (closingIdx === -1) {
+    return undefined;
+  }
+
+  let bodyStart = closingIdx + delim.length;
+  if (content.startsWith("\r\n", bodyStart)) {
+    bodyStart += 2;
+  } else if (content.startsWith("\n", bodyStart)) {
+    bodyStart += 1;
+  }
+
+  return {
+    body: content.slice(bodyStart),
+    frontmatter: content.slice(0, bodyStart),
+  };
+}
+
+export { requiresFrontmatter, splitFrontmatter };

--- a/packages/runtime/src/util/frontmatter.ts
+++ b/packages/runtime/src/util/frontmatter.ts
@@ -1,3 +1,7 @@
+import { parse } from "smol-toml";
+import * as vb from "valibot";
+import { parse as parseYaml } from "yaml";
+
 /**
  * Utility for preserving frontmatter in block/skill files during write and str-replace operations.
  *
@@ -5,6 +9,44 @@
  * Skill files use YAML frontmatter delimited by `---...---`.
  * In both cases the frontmatter is REQUIRED — the loading code throws if it's missing or malformed.
  */
+
+const BlockFrontmatterSchema = vb.object({
+  description: vb.string(),
+});
+
+const SkillFrontmatterSchema = vb.object({
+  description: vb.pipe(vb.string(), vb.nonEmpty()),
+  name: vb.pipe(vb.string(), vb.nonEmpty()),
+});
+
+/**
+ * Validates that the frontmatter in the given content string is parseable
+ * (TOML for blocks, YAML for skills) and matches the expected Valibot schema.
+ * Throws a descriptive Error on failure.
+ */
+function validateFrontmatter(content: string, isBlock: boolean): void {
+  const delim = isBlock ? "+++" : "---";
+  const schema = isBlock ? BlockFrontmatterSchema : SkillFrontmatterSchema;
+
+  if (!content.startsWith(delim)) {
+    throw new Error(`Invalid frontmatter: expected file to start with '${delim}'`);
+  }
+
+  const closingIdx = content.indexOf(delim, delim.length);
+  if (closingIdx === -1) {
+    throw new Error(`Invalid frontmatter: missing closing '${delim}'`);
+  }
+
+  const rawData = content.slice(delim.length, closingIdx);
+
+  try {
+    const parsed: unknown = isBlock ? parse(rawData) : parseYaml(rawData);
+    vb.parse(schema, parsed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid frontmatter: ${message}`, { cause: error });
+  }
+}
 
 /**
  * Returns true when a sandbox path refers to a file type that requires frontmatter.
@@ -55,4 +97,10 @@ function splitFrontmatter(
   };
 }
 
-export { requiresFrontmatter, splitFrontmatter };
+export {
+  requiresFrontmatter,
+  splitFrontmatter,
+  validateFrontmatter,
+  BlockFrontmatterSchema,
+  SkillFrontmatterSchema,
+};

--- a/packages/runtime/src/util/load.ts
+++ b/packages/runtime/src/util/load.ts
@@ -11,11 +11,8 @@ import type { MemoryBlock } from "#engine/block.js";
 import type { Session } from "#harness/session.js";
 import colors from "#output/colors.js";
 import { getMatchingBlockNames } from "#util/conditions.js";
+import { BlockFrontmatterSchema, SkillFrontmatterSchema } from "#util/frontmatter.js";
 import { root } from "#util/paths.js";
-
-const BlockFrontmatterSchema = vb.object({
-  description: vb.string(),
-});
 
 type Frontmatter = Omit<MemoryBlock, "content" | "label" | "metadata" | "filePath">;
 
@@ -119,11 +116,6 @@ interface Skill {
   description: string;
 }
 
-const FrontmatterSchema = vb.object({
-  description: vb.pipe(vb.string(), vb.nonEmpty()),
-  name: vb.pipe(vb.string(), vb.nonEmpty()),
-});
-
 async function loadSkills(agentSlug: string): Promise<Skill[]> {
   const skillsPath = path.join(root(), "agents", agentSlug, "skills");
 
@@ -162,7 +154,7 @@ async function loadSkills(agentSlug: string): Promise<Skill[]> {
     }
 
     const yamlData = content.slice(3, ending);
-    const frontmatter = vb.parse(FrontmatterSchema, parseYaml(yamlData));
+    const frontmatter = vb.parse(SkillFrontmatterSchema, parseYaml(yamlData));
 
     skills.push({
       description: frontmatter.description,
@@ -219,7 +211,7 @@ async function loadConditionalBlocks(
   return blocks;
 }
 
-export type { Frontmatter, BlockLabel, Skill };
+export type { BlockLabel, Skill };
 export {
   labels as blockLabels,
   loadBlocks,


### PR DESCRIPTION
There's been some issues with the frontmatter getting decimated by agents.

Well, no more. This PR should un-fuck most cases where it can happen. There are still *obviously* cases where it can, but we can only cover so much surface-area when it's infinite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security-Critical Analysis — Updated

The prior validation gap has been addressed: frontmatter is now parsed and semantically validated before being preserved or accepted.

What changed (security-relevant):
- Frontmatter parsing & Valibot schemas were centralized in packages/runtime/src/util/frontmatter.ts (BlockFrontmatterSchema, SkillFrontmatterSchema) with a new validateFrontmatter(content, isBlock) function that enforces delimiters, parses TOML/YAML, and runs Valibot validation.
- write.ts validates preserved frontmatter from existing block/skill files before prepending it to new content, and also validates agent-provided frontmatter on creation of new block/skill files (when the content starts with the expected delimiter).
- str-replace.ts validates preserved frontmatter before writing when it extracted frontmatter for scoped body edits.
- load.ts now imports and uses the shared schemas (BlockFrontmatterSchema, SkillFrontmatterSchema) for runtime loading/validation.

Impact:
- The risk that malformed frontmatter could be silently preserved by write/str-replace and cause downstream load-time failures has been mitigated because preserved frontmatter is validated prior to write.
- Agents still can produce invalid frontmatter, but they will now receive immediate validation errors during write/str-replace operations rather than causing later load failures.

Other security notes:
- Path isolation and sandbox path checks are unchanged by this PR.
- Parsing/validation behavior is stricter and centralized, improving consistency and reducing the previously-identified attack surface where corrupted frontmatter could propagate silently.

Recommendation:
- None required immediately; the PR implements the recommended validation. Continue to monitor tests covering failure modes (invalid/missing fields, malformed TOML/YAML) added with the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->